### PR TITLE
Fix gh-page index page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
 This repo holds the sources for the [Pointer Events][1] spec.
 
-   [1]: https://w3c.github.io/pointerevents/pointerEvents.html
+   [1]: https://w3c.github.io/pointerevents/index.html
 


### PR DESCRIPTION
Readme points to the old gh-pages index page. Since it is changed from `pointerEvents.html` to `index.html`, the page is 404.
