### PR TITLE
Add missing pointerleave

### DIFF
--- a/index.html
+++ b/index.html
@@ -864,6 +864,7 @@ these pointers will all produce <a href="#compatibility-mapping-with-mouse-event
 				<li><code>click</code></li>
 				<li><code>pointerout</code></li>
 				<li><code>mouseout</code></li>
+				<li><code>pointerleave</code></li>
 				<li><code>mouseleave</code></li>
 			</ol>
 			<p>If, however, the <code>pointerdown</code> event is canceled during this interaction then the sequence of events would be:
@@ -879,6 +880,7 @@ these pointers will all produce <a href="#compatibility-mapping-with-mouse-event
 				<li><code>click</code></li>
 				<li><code>pointerout</code></li>
 				<li><code>mouseout</code></li>
+				<li><code>pointerleave</code></li>
 				<li><code>mouseleave</code></li>
 			</ol>			
 			</section>


### PR DESCRIPTION
Somehow the `pointerleave` fell by the wayside in the non-normative note about expected events for non-hover capable devices.

This fixup would also apply to the current level 1 spec. Possible to add that to the actual REC as a quick fix?
