### PR TITLE
Add the missing pointerover/enter events

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,7 +421,11 @@ these pointers will all produce <a>compatibility mouse events</a>.</div>
             <h4>Process Pending Pointer Capture</h4>
             <p>Whenever a user agent is to fire a Pointer Event that is not <code>gotpointercapture</code> or <code>lostpointercapture</code>, it must first run these steps:</p>
             <ol>
-                <li>If the <a>pointer capture target override</a> for this pointer is set and is not equal to the <a>pending pointer capture target override</a>, then fire a pointer event named <code>lostpointercapture</code> at the <a>pointer capture target override</a> node.</li>
+                <li>If the <a>pointer capture target override</a> for this pointer is set and is not equal to the <a>pending pointer capture target override</a>, then fire a pointer event named <code>lostpointercapture</code> at the <a>pointer capture target override</a> node.
+                    <ul>
+                        <li>Further, if the <a>pending pointer capture target override</a> is not set and, the <a>pointer capture target override</a> is not equal to the hit test node for the pointer event which invoked this process, then fire a pointer event named <code>pointerover</code> and a pointer event named <code>pointerenter</code> at the hit test node.</li>
+                    </ul>
+                </li>
                 <li>If the <a>pending pointer capture target override</a> for this pointer is set and is not equal to the <a>pointer capture target override</a>, then fire a pointer event named <code>gotpointercapture</code> at the <a>pending pointer capture target override</a>. 
                     <ul>
                         <li>Further, if the <a>pointer capture target override</a> is not set and, the <a>pending pointer capture target override</a> is not equal to the hit test node for the pointer event which invoked this process, and the hit test node has received <code>pointerover</code> and <code>pointerenter</code> events, then fire a pointer event named <code>pointerout</code> and a pointer event named <code>pointerleave</code> at the hit test node.</li>


### PR DESCRIPTION
In "Process Pending Pointer Capture" section, likewise the
pointerout/leave that is mentioned in this section in some
cases we need to send pointerover/enter when the capture
is lost and pointer is on another node that is not the
capturing node.
