### PR TITLE
Switch to the W3C Software and Document license

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
           shortName:            "pointerevents-level-2",
           noIDLSorting:         true,
           edDraftURI:           "https://w3c.github.io/pointerevents/",
+          license:		"w3c-software-doc",
 
           // editors, add as many as you like
           // only "name" is required


### PR DESCRIPTION
As specified by the [3/15/16 charter](https://www.w3.org/2012/pointerevents/charter/)
