### PR TITLE
Rewrite of primary pointer section

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,28 +359,16 @@ eventTarget.dispatchEvent(event);
 		</section>
 		<section>
 			<h2><dfn>The Primary Pointer</dfn></h2>
-			<div><p>In a multi-pointer (e.g. multi-touch) scenario, the <a href="#widl-PointerEvent-isPrimary"><code>isPrimary</code></a> property is used to identify a master pointer amongst the set of active pointers for each pointer type.  Only a primary pointer will produce <a>compatibility mouse events</a>. Authors who desire single-pointer interaction can achieve this by ignoring non-primary pointers (however, see the note below on <a href="#multiple-primary-pointers">multiple primary pointers</a>).</p></div>
-			<section>
-				<h3>Determining the primary pointer</h3>
-				<div>When firing a pointer event, a pointer is considered primary if:
-					<ul>
-						<li>The pointer represents a primary mouse input.</li>
-						<li>The pointer represents a primary touch input.</li>
-						<li>The pointer represents a primary pen input.</li>
-					</ul>
-				</div>
-				<dl>
-					<dt>primary mouse input</dt><dd>A pointer representing mouse input is considered the <i>primary mouse input</i> if it dispatched any pointer events (such as <code>pointerdown</code> or <code>pointermove</code>) when no other active pointers representing a mouse input existed. However, see the note about <a href="#multiple-mouse-inputs">multiple mouse inputs</a>.</dd>
-					<dt>primary touch input</dt><dd>A pointer representing touch input is considered the <i>primary touch input</i> if its <code>pointerdown</code> event was dispatched when no other active pointers representing touch input existed.</dd>
-					<dt>primary pen input</dt><dd>A pointer representing pen input is considered the <i>primary pen input</i> if its <code>pointerdown</code> event was dispatched when no other active pointers representing pen input existed.</dd>
-				</dl>
-				<div class="note" id="multiple-mouse-inputs">Current operating systems and user agents don't usually have a concept of multiple mouse inputs. When more than one mouse device is present (for instance, on a laptop with both a trackpad and an external mouse), all mouse devices are generally treated as a single device - movements on any of the devices are translated to movement of a single mouse pointer, and there is no distinction between button presses on different mouse devices. For this reason, there will usually only be a single mouse pointer, and that pointer will be primary.</div>
-				<div class="note" id="multiple-primary-pointers">When two or more pointer device types are being used concurrently, multiple pointers (one for each <code>pointerType</code>) are considered primary. For example, a touch contact and a mouse cursor moved simultaneously will produce pointers that are both considered primary.</div>
-				<div class="note">In the case where there are multiple <a href="#the-primary-pointer">primary pointers</a>, 
-these pointers will all produce <a>compatibility mouse events</a>.</div>
-				<div class="note">In some cases, it is possible for the user agent to fire pointer events in which no pointer is marked as a primary pointer. For instance, when there are multiple active pointers of a particular type like multi-touch and the primary pointer is removed (e.g. it leaves the screen), there will be no primary pointer events. Also on the platforms where the primary pointer is determined using all active pointers on the device (including those targeted at an application other than the user agent), if the first touch interaction is targeted outside the user agent and a secondary (multi-touch) touch interaction is targeted inside the user agent, then the user agent may fire pointer events for the second contact with a value of <code>false</code> for <code>isPrimary</code>.</div>
-				
-			</section>
+			<div><p>In a multi-pointer (e.g. multi-touch) scenario, the <a href="#widl-PointerEvent-isPrimary"><code>isPrimary</code></a> property is used to identify a master pointer amongst the set of <a data-lt="active pointer">active pointers</a> for each pointer type.</p></div>
+			<ul>
+				<li>At any given time, there can only ever be at most one primary pointer for each pointer type.</li>
+				<li>The first pointer to become active for a particular pointer type (e.g. the first finger to touch the screen in a multi-touch interaction) becomes the primary pointer for that pointer type.</li>
+				<li>Only a primary pointer will produce <a>compatibility mouse events</a>. In the case where there are multiple <a href="#the-primary-pointer">primary pointers</a>, these pointers will all produce <a>compatibility mouse events</a>.</li>
+			</ul>
+			<div class="note">Authors who desire single-pointer interaction can achieve this by ignoring non-primary pointers (however, see the note below on <a href="#multiple-primary-pointers">multiple primary pointers</a>).</p></div>
+			<div class="note" id="multiple-primary-pointers">When two or more pointer device types are being used concurrently, multiple pointers (one for each <code>pointerType</code>) are considered primary. For example, a touch contact and a mouse cursor moved simultaneously will produce pointers that are both considered primary.</div>
+			<div class="note">In some cases, it is possible for the user agent to fire pointer events in which no pointer is marked as a primary pointer. For instance, when there are multiple active pointers of a particular type like multi-touch and the primary pointer is removed (e.g. it leaves the screen), there will be no primary pointer events. Also on the platforms where the primary pointer is determined using all active pointers on the device (including those targeted at an application other than the user agent), if the first touch interaction is targeted outside the user agent and a secondary (multi-touch) touch interaction is targeted inside the user agent, then the user agent may fire pointer events for the second contact with a value of <code>false</code> for <code>isPrimary</code>.</div>
+			<div class="note" id="multiple-mouse-inputs">Current operating systems and user agents don't usually have a concept of multiple mouse inputs. When more than one mouse device is present (for instance, on a laptop with both a trackpad and an external mouse), all mouse devices are generally treated as a single device - movements on any of the devices are translated to movement of a single mouse pointer, and there is no distinction between button presses on different mouse devices. For this reason, there will usually only be a single mouse pointer, and that pointer will be primary.</div>
 		</section>
      </section>
 	 <section>

--- a/index.html
+++ b/index.html
@@ -364,15 +364,17 @@ eventTarget.dispatchEvent(event);
 				<h3>Determining the primary pointer</h3>
 				<div>When firing a pointer event, a pointer is considered primary if:
 					<ul>
-						<li>The pointer represents a mouse device.</li>
+						<li>The pointer represents a primary mouse input.</li>
 						<li>The pointer represents a primary touch input.</li>
 						<li>The pointer represents a primary pen input.</li>
 					</ul>
 				</div>
 				<dl>
+					<dt>primary mouse input</dt><dd>A pointer representing mouse input is considered the <i>primary mouse input</i> if it dispatched any pointer events (such as <code>pointerdown</code> or <code>pointermove</code>) when no other active pointers representing a mouse input existed. However, see the note about <a href="#multiple-mouse-inputs">multiple mouse inputs</a>.</dd>
 					<dt>primary touch input</dt><dd>A pointer representing touch input is considered the <i>primary touch input</i> if its <code>pointerdown</code> event was dispatched when no other active pointers representing touch input existed.</dd>
 					<dt>primary pen input</dt><dd>A pointer representing pen input is considered the <i>primary pen input</i> if its <code>pointerdown</code> event was dispatched when no other active pointers representing pen input existed.</dd>
 				</dl>
+				<div class="note" id="multiple-mouse-inputs">Current operating systems and user agents don't usually have a concept of multiple mouse inputs. When more than one mouse device is present (for instance, on a laptop with both a trackpad and an external mouse), all mouse devices are generally treated as a single device - movements on any of the devices are translated to movement of a single mouse pointer, and there is no distinction between button presses on different mouse devices. For this reason, there will usually only be a single mouse pointer, and that pointer will be primary.</div>
 				<div class="note" id="multiple-primary-pointers">When two or more pointer device types are being used concurrently, multiple pointers (one for each <code>pointerType</code>) are considered primary. For example, a touch contact and a mouse cursor moved simultaneously will produce pointers that are both considered primary.</div>
 				<div class="note">In the case where there are multiple <a href="#the-primary-pointer">primary pointers</a>, 
 these pointers will all produce <a>compatibility mouse events</a>.</div>


### PR DESCRIPTION
This generalises the treatment of mouse inputs to allow for the possibility of systems that support more than one simultaneous and independent mouse device, while at the same time clarifying that currently most (all?) operating systems/user agents don't have a concept of multiple mouse pointers. 

It future-proofs the spec while also reflecting reality.

Closes #49 
