### PR TITLE
Update revision history

### DIFF
--- a/index.html
+++ b/index.html
@@ -928,52 +928,18 @@ eventTarget.dispatchEvent(event);
     </section>
 	<section class='appendix informative'>
 		<h1>Revision History</h1>
-		<p>The following is an informative summary of substantial and major editorial changes between publications of this specification. A complete revision history of the Editor's Drafts of this specification can be found <a href="https://github.com/w3c/pointerevents/commits">here</a>.</p>
-		<h3>Changes Since the 24 February 2015 Recommendation (begin Level 2)</h3>
+		<p>The following is an informative summary of substantial and major editorial changes between publications of this specification, relative to the first [[PointerEvents]] specification. See the <a href="https://github.com/w3c/pointerevents/commits">complete revision history of the Editor's Drafts of this specification</a>.</p>
+		<h3>Changes since the 24 February 2015 Recommendation</h3>
 		<ul>
-			<li><a href="https://lists.w3.org/Archives/Public/public-pointer-events/2015AprJun/0048.html">Mail</a> - Add direction-specific touch-action values (pan-left, pan-right, pan-up, pan-down) and clarified behavior of existing pan-x and pan-y values.</li>
-		</ul>
-    <h3>Changes Since the 13 November 2014 Last Call Draft</h3>
-    <ul>
-      <li><a href="http://lists.w3.org/Archives/Public/public-pointer-events/2014OctDec/0094.html">Mail</a> - various editorial changes and clarification and added non-normative author guidance for maxTouchPoints</li>
-    </ul>
-		<h3>Changes Since the 09 May 2013 Candidate Recommendation</h3>
-		<ul>
-			<li><a href="http://lists.w3.org/Archives/Public/public-pointer-events/2013OctDec/0028.html">Mail</a> - Clarified pointerover/pointerout behavior with pointer capture</li>
-			<li><a href="http://lists.w3.org/Archives/Public/public-pointer-events/2013OctDec/0010.html">Mail</a> - Clarified maxTouchPoints behavior on platforms with less granular information</li>
-		</ul>
-		<h3>Changes Since the 19 February 2013 Last Call Draft</h3>
-		<ul>
-			<li><a href="http://lists.w3.org/Archives/Public/public-pointer-events/2013JanMar/0110.html">Mail</a> - Examples moved to front of spec</li>
-			<li><a href="http://lists.w3.org/Archives/Public/public-pointer-events/2013JanMar/0169.html">Mail</a> - Clarified contextmenu is not a compatibility mouse event</li>
-			<li><a href="http://lists.w3.org/Archives/Public/public-pointer-events/2013JanMar/0146.html">Mail</a> - Added non-normative note about pointerId selection algorithm
-			<li><a href="http://www.w3.org/2013/03/26-pointerevents-minutes.html#item06">Mail</a> - Add missing Document, Window definitions for pointer event handlers</li>
-			<li><a href="https://dvcs.w3.org/hg/pointerevents/rev/91af8c100600">Mail</a> - Clarified pointer capture events are asynchronous</li>
-			<li><a href="https://dvcs.w3.org/hg/pointerevents/rev/9e15214ee5c5">Mail</a> - Clarified multiple primary pointers may be active at once</li>
-			<li><a href="https://dvcs.w3.org/hg/pointerevents/rev/0da5982bcc84">Mail</a> - Clarified spec positioning in introduction</li>
-			<li><a href="https://dvcs.w3.org/hg/pointerevents/rev/d24dd1d54803">Mail</a> - Moved constructor dictionary to be next to PointerEvent definition</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=21746">21746</a> - Removed contradictory requirement for pointerId to be 1 for mouse</li>
-			<li><a href="http://lists.w3.org/Archives/Public/public-pointer-events/2013AprJun/0064.html">Mail</a> - Clarified block-level restriction for touch-action</li>
-		</ul>
-		<h3>Last Call Draft dated 19 February 2013</h3>
-		<ul>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20710">20710</a> - Clarified the touch-action processing model.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20217">20217</a> - Expanded touch-action property to include additional values: pan-x and pan-y.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20109">20109</a> - Changed emulation value for devices that do not support pressure from 1 to 0.5, added emulation for width/height</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20222">20222</a> - Clarified that for hover menus the behavior is implementation-defined.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20872">20872</a> - Clarified that multiple concurrent pointers can be primary.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=21032">21032</a> - Reworded introduction to clarify goals</li>
-		</ul>
-		<h3>Second Working Draft dated 15 January 2013</h3>
-		<ul>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20107">20107</a> - Added a new set of button and buttons values to accommodate pen contact with eraser button pressed.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20108">20108</a> - Added additional pointer capture details.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20109">20109</a> - Added emulation (default values) for devices that do not support pressure.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20112">20112</a> - Added pointerenter and pointerleave events using the same model as mouseenter and mouseleave.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20219">20219</a> - Changed pointerType from long to DOMString.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20220">20220</a> - Removed hwTimestamp in favor of a future DOM Event high-resolution timestamp.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20221">20221</a> - Added constructor dictionary for PointerEvent.</li>
-			<li><a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20281">20281</a> - Changed width and height to be CSS pixels instead of device pixels.</li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/69">Make width/height default to 1, remove UA "guessing"/faking geometry</a></li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/56">Made mouseover/out/enter/leave event firing independent of corresponding PEs</a></li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/53">Rewrite of primary pointer section</a> to simplify the wording and allow for possibility of multiple mouse input devices</li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/50">Cover the case when primary pointer is removed</a></li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/43">Clarification about dynamic touch-action changes</a></li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/36">Add the missing pointerover/enter events</a> to the "Process Pending Pointer Capture" section</li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/34">Clarify the button value for mouse drag</a></li>
+      <li><a href="https://github.com/w3c/pointerevents/pull/24">Fix the touch-action processing model for zoom scenarios</a></li>
+			<li><a href="https://github.com/w3c/pointerevents/pull/13">Add direction-specific touch-action values</a> (pan-left, pan-right, pan-up, pan-down) and clarified behavior of existing pan-x and pan-y values.</li>
 		</ul>
 	</section>
 	<!-- appendix -->


### PR DESCRIPTION
Removed revision history for PE Level 1, clarified revision history is
relative to PE Level 1, added major substantive/editorial changes to
date (for simplicity, linking directly to GitHub PRs)
