### PR TITLE
update abstract/sotd

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,11 +91,11 @@
   </head>
   <body>
     <section id='abstract'>
-        <p>The features in this specification extend or modify those found in [[PointerEvents]], a W3C Recommendation that describes events and related interfaces for handling hardware agnostic pointer input from devices including a mouse, pen, touchscreen, etc. For compatibility with existing mouse based content, this specification also describes a mapping to fire [[DOM-LEVEL-3-EVENTS]] Mouse Events for other pointer device types.</p>
+        <p>The features in this specification extend or modify those found in Pointer Events, a W3C Recommendation that describes events and related interfaces for handling hardware agnostic pointer input from devices including a mouse, pen, touchscreen, etc. For compatibility with existing mouse based content, this specification also describes a mapping to fire Mouse Events for other pointer device types.</p>
     </section>
 
     <section id="sotd">
-        <p>This specification is an update to Pointer Events Level 1 which was shipped broadly only by Microsoft Internet Explorer and Microsoft Edge (though a further independent and mostly interoperable implementation was present in a pre-release build of Mozilla Firefox when the Pointer Events specification was published as a W3C Recommendation). Level 2 includes editorial clarifications, new features and minor breaking changes that address certain limitations and concerns that have been raised about aspects of the design, in an effort to enable wider browser adoption.</p>
+        <p>This specification is an update to [[PointerEvents]] which was shipped broadly only by Microsoft Internet Explorer and Microsoft Edge (though a further independent and mostly interoperable implementation was present in a pre-release build of Mozilla Firefox when the Pointer Events specification was published as a W3C Recommendation). Level 2 includes editorial clarifications, new features and minor breaking changes that address certain limitations and concerns that have been raised about aspects of the design, in an effort to enable wider browser adoption.</p>
     </section>
 
     <section id="intro" class="informative">


### PR DESCRIPTION
remove links in abstract, move link to PE1 to sotd (DOM3 events already
linked to from sotd)

addresses https://github.com/w3c/pointerevents/pull/108#issuecomment-233709543
