### PR TITLE
Add ReSpec "no-link-warnings"

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@ eventTarget.dispatchEvent(event);</code>
         <section>
             <h2><code>PointerEvent</code> Interface</h2>
             <div>
-              <pre class="idl">
+              <pre class="idl no-link-warnings">
 dictionary PointerEventInit : MouseEventInit {
     long        pointerId = 0;
     double      width = 1;


### PR DESCRIPTION
Suppress warnings for missing definitions of the dictionary properties in ReSpec - see https://github.com/w3c/respec/issues/1027#issuecomment-273000561

Resolves last outstanding warnings from https://github.com/w3c/pointerevents/pull/168