### PR TITLE
Add pan/zoom in the non-normative examples for pointercancel

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,6 +580,7 @@ interface PointerEvent : MouseEvent {
                         <li>A device's screen orientation is changed while a pointer is active.</li>
                         <li>The user inputs a greater number of simultaneous pointers than is supported by the device.</li>
                         <li>The user agent interprets the input as accidental (for example, the hardware supports palm rejection).</li>
+                        <li>The user agent interprets the input as a pan or zoom gesture.</li>
                     </ul>
                     <p>Methods for changing the device's screen orientation, recognizing accidental input, or using a pointer to manipulate the viewport (e.g. panning or zooming) are out of scope for this specification.</p>
                 </div>


### PR DESCRIPTION
panning/zooming is mentioned in the paragraph after the bullet list, but not actually present as a bullet point. adding it here makes it more immediately obvious.