### PR TITLE
Change respecConf URLs from http to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,6 +580,7 @@ interface PointerEvent : MouseEvent {
                         <li>A device's screen orientation is changed while a pointer is active.</li>
                         <li>The user inputs a greater number of simultaneous pointers than is supported by the device.</li>
                         <li>The user agent interprets the input as accidental (for example, the hardware supports palm rejection).</li>
+                        <li>The user agent interprets the input as a pan or zoom gesture.</li>
                     </ul>
                     <p>Methods for changing the device's screen orientation, recognizing accidental input, or using a pointer to manipulate the viewport (e.g. panning or zooming) are out of scope for this specification.</p>
                 </div>

--- a/index.html
+++ b/index.html
@@ -11,17 +11,17 @@
           shortName:            "pointerevents2",
           noIDLSorting:         true,
           edDraftURI:           "https://w3c.github.io/pointerevents/",
-          license:        "w3c-software-doc",
+          license:              "w3c-software-doc",
 
           // editors, add as many as you like
           // only "name" is required
           editors:  [
               { name: "Jacob Rossi",
-                company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
+                company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
               { name: "Matt Brubeck",
-                company: "Mozilla", companyURL: "http://www.mozilla.org/" },
+                company: "Mozilla", companyURL: "https://www.mozilla.org/" },
               { name: "Rick Byers",
-                company: "Google", companyURL: "http://www.google.com/" },
+                company: "Google", companyURL: "https://www.google.com/" },
               { name: "Patrick H. Lauke",
                 company: "The Paciello Group", companyURL: "https://www.paciellogroup.com/" }
           ],
@@ -54,13 +54,13 @@
           wg:           "Pointer Events Working Group",
 
           // URI of the public WG page
-          wgURI:        "http://www.w3.org/2012/pointerevents/",
+          wgURI:        "https://www.w3.org/2012/pointerevents/",
 
           // name (with the @w3c.org) of the public mailing to which comments are due
           wgPublicList: "public-pointer-events",
 
           // URI of the patent status for this WG, for Rec-track documents
-          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/59096/status",
+          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/59096/status",
 
           // previous REC spec
           prevRecShortname: 'pointerevents',
@@ -75,7 +75,7 @@
                     "Alex Russell",
                     "Robin Berjon"
                 ],
-                "href": "http://www.w3.org/TR/dom/",
+                "href": "https://www.w3.org/TR/dom/",
                 "publisher": "W3C",
                 "status": "Last Call Working Draft",
                 "title": "W3C DOM4"


### PR DESCRIPTION
Addresses ReSpec warning "There are insecure URLs in your respecConfig!
Please change the following properties to use 'https://': wgURI,
wgPatentURI."