### PR TITLE
Add notes about touch-action and direct/indirect manipulation and stylus

### DIFF
--- a/index.html
+++ b/index.html
@@ -967,18 +967,23 @@ partial interface Navigator {
     </section>
     <section class="appendix">
         <h1>Acknowledgments</h1>
-        <p>Many thanks to lots of people for their proposals and recommendations, some of which are incorporated into this document. The group's Chair acknowledges contributions from the following group members:
+        <p>Many thanks to lots of people for their proposals and recommendations, some of which are incorporated into this document. The group's Chair acknowledges contributions from the following past and present group members and participants:
+            Mustaq Ahmed,
             Arthur Barstow,
             Matt Brubeck,
-            Rick Byers, 
-            Cathy Chan, 
-            Scott González, 
-            Patrick H. Lauke, 
+            Rick Byers,
+            Cathy Chan,
+            Ted Dinklocker,
+            Dave Fleck,
+            Scott González,
+            Patrick H. Lauke,
             Sangwhan Moon,
-            Olli Pettay, 
-            Jacob Rossi, 
-            Doug Schepers and
-            Asir Vedamuthu.
+            Olli Pettay,
+            Jacob Rossi,
+            Doug Schepers,
+            Dave Tapuska,
+            Asir Vedamuthu,
+            Navid Zolghadr
         </p>
         <p>Special thanks to those that helped pioneer the first edition of this model, including especially: Charu Chandiram, Peter Freiling, Nathan Furtwangler, Thomas Olsen, Matt Rakow, Ramu Ramanathan, Justin Rogers, Jacob Rossi, Reed Townsend and Steve Wright.</p>
     </section>

--- a/index.html
+++ b/index.html
@@ -721,6 +721,7 @@ partial interface Navigator {
         <h1>Declaring candidate regions for default touch behaviors</h1>
         <p>For touch input, the default action of any and all pointer events MUST NOT be a manipulation of the viewport (e.g. panning or zooming).</p>
         <div class="note">Touch manipulations are intentionally not a default action of pointer events. Removing this dependency on the cancellation of events facilitates performance optimizations by the user agent.</div>
+        <div class="note">While the issue of pointers used to manipulate the viewport is generally limited to touch input (where a user's finger can both interact with content and pan/zoom the page), certain user agents may also allow the same types of (direct or indirect) manipulation for other pointer types. For instance, on mobile/tablet devices, users may also be able to pan using a stylus. This section applies to these scenarios as well (despite the specification's use of "touch").</div>
         <section>
             <h2>The <code>touch-action</code> CSS property</h2>
             <table class="simple">
@@ -735,6 +736,8 @@ partial interface Navigator {
             </table>
 
             <p>The <code>touch-action</code> CSS property determines whether touch input MAY  trigger default behavior supplied by user agent.  This includes, but is not limited to, behaviors such as panning or zooming.</p>
+
+            <div class="note">As noted previously, in the case of user agents that allow default behaviors (such as panning or zooming) for other pointer types, these user agents MUST apply the same consideration for those pointer types. For instance, if a user agent allows panning/zooming with a stylus, the user agent must take into account the relevant <code>touch-action</code> value when determining which default behaviors it should handle.</div>
 
             <p>When a user touches an element, the effect of that touch is determined by the value of the <code>touch-action</code> property and the default touch behaviors on the element and its ancestors.  A touch behavior is supported if allowed by the <code>touch-action</code> properties of all elements between the hit tested element and it's nearest ancestor with the default touch behavior (including both the hit tested element and the element with the default touch behavior).</p>
 


### PR DESCRIPTION
It's too late of course to change "touch-action" and to generalise the
language in this whole section, but...with these notes, certain
scenarios such as Samsung Galaxy Note (where you CAN pan with a stylus,
and where touch-action DOES have the correct effect the same way as for
touch) are more explicitly covered.

Conversely, on a Surface 3, you CAN'T pan with the Surface Pen - so
touch-action does NOT have any effect here (since the browser doesn't
have any default behavior here that needs to be dealt with/suppressed)