### PR TITLE
Define the interation of drag operation vs capture

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,10 +861,12 @@ partial interface Navigator {
         <section>
             <h3>Implicit Release of Pointer Capture</h3>
             <p>Immediately after firing the <code>pointerup</code> or <code>pointercancel</code> events, a user agent MUST clear the <a>pending pointer capture target override</a> for the <code>pointerId</code> of the <code>pointerup</code> or <code>pointercancel</code> event that was just dispatched, and then run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps to fire <code>lostpointercapture</code> if necessary.</p>
-            <p>Immediately before firing <code>dragstart</code> event [[!HTML]],
-a user agent MUST clear the <a>pending pointer capture target override</a> for the pointer that caused the drag operation,
-and then run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps to fire <code>lostpointercapture</code>
-before the <code>dragstart</code> event if necessary.</p>
+            <p>Immediately before <a href="https://html.spec.whatwg.org/multipage/dnd.html#initiate-the-drag-and-drop-operation">drag operation starts</a> [[!HTML]],
+a user agent MUST send a <code>pointercancel</code> for the pointer that caused the drag operation.
+This <code>pointercancel</code> will follow the paragraph above regarding releasing the capture.</p>
+<div class="note">If the drag operation initiation is prevented through any means
+(e.g. calling <code<preventDefault</code> the <code>dragstart</code> event)
+there will be no need for the <code>pointercancel</code>.</div>
             <p>If the user agent supports firing the <code>click</code> event (see <a title="compatibility mouse events" href="#dfn-compatibility-mouse-events">compatibility mouse events</a>) and if in an implicit release scenario both <code>click</code> and <code>lostpointercapture</code> events are fired, <code>click</code> should be fired before <code>lostpointercapture</code>.</p>
             <p>When the <a>pointer capture target override</a> is removed from its <code>ownerDocument</code>'s tree, clear the <a>pending pointer capture target override</a> and <a>pointer capture target override</a> nodes and fire a PointerEvent named <code>lostpointercapture</code> at the document.</p>
         </section>

--- a/index.html
+++ b/index.html
@@ -567,11 +567,11 @@ interface PointerEvent : MouseEvent {
                     <li>The user agent has determined that a pointer is unlikely to continue to produce events (for example, because of a hardware event).</li>
                     <li>After having fired the <code>pointerdown</code> event, if the pointer is subsequently used to manipulate the page viewport (e.g. panning or zooming).</li>
                     <li>Immediately before <a href="https://html.spec.whatwg.org/multipage/dnd.html#initiate-the-drag-and-drop-operation">drag operation starts</a> [[!HTML]],
-                     for the pointer that caused the drag operation.</li>
+                     for the pointer that caused the drag operation.
+                     <div class="note">If the start of the drag operation is prevented through any means
+                     (e.g. through calling <code>preventDefault</code> on the <code>dragstart</code> event)
+                     there will be no <code>pointercancel</code> event.</div></li>
                 </ul>
-<div class="note">If the start of the drag operation is prevented through any means
-(e.g. through calling <code>preventDefault</code> on the <code>dragstart</code> event)
-there will be no <code>pointercancel</code> event.</div>
                 <p>After firing the <code>pointercancel</code> event, a user agent MUST also fire a pointer event named <code>pointerout</code> followed by firing a pointer event named <code>pointerleave</code>.</p>
                 <div class="note">
                     <p><i>This section is non-normative.</i></p>

--- a/index.html
+++ b/index.html
@@ -566,7 +566,12 @@ interface PointerEvent : MouseEvent {
                 <ul>
                     <li>The user agent has determined that a pointer is unlikely to continue to produce events (for example, because of a hardware event).</li>
                     <li>After having fired the <code>pointerdown</code> event, if the pointer is subsequently used to manipulate the page viewport (e.g. panning or zooming).</li>
+                    <li>Immediately before <a href="https://html.spec.whatwg.org/multipage/dnd.html#initiate-the-drag-and-drop-operation">drag operation starts</a> [[!HTML]],
+                     for the pointer that caused the drag operation.</li>
                 </ul>
+<div class="note">If the start of the drag operation is prevented through any means
+(e.g. through calling <code>preventDefault</code> on the <code>dragstart</code> event)
+there will be no <code>pointercancel</code> event.</div>
                 <p>After firing the <code>pointercancel</code> event, a user agent MUST also fire a pointer event named <code>pointerout</code> followed by firing a pointer event named <code>pointerleave</code>.</p>
                 <div class="note">
                     <p><i>This section is non-normative.</i></p>
@@ -862,12 +867,6 @@ partial interface Navigator {
         <section>
             <h3>Implicit Release of Pointer Capture</h3>
             <p>Immediately after firing the <code>pointerup</code> or <code>pointercancel</code> events, a user agent MUST clear the <a>pending pointer capture target override</a> for the <code>pointerId</code> of the <code>pointerup</code> or <code>pointercancel</code> event that was just dispatched, and then run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps to fire <code>lostpointercapture</code> if necessary.</p>
-            <p>Immediately before <a href="https://html.spec.whatwg.org/multipage/dnd.html#initiate-the-drag-and-drop-operation">drag operation starts</a> [[!HTML]],
-a user agent MUST send a <code>pointercancel</code> for the pointer that caused the drag operation.
-This <code>pointercancel</code> will follow the paragraph above regarding releasing the capture.</p>
-<div class="note">If the drag operation initiation is prevented through any means
-(e.g. calling <code<preventDefault</code> the <code>dragstart</code> event)
-there will be no need for the <code>pointercancel</code>.</div>
             <p>If the user agent supports firing the <code>click</code> event (see <a title="compatibility mouse events" href="#dfn-compatibility-mouse-events">compatibility mouse events</a>) and if in an implicit release scenario both <code>click</code> and <code>lostpointercapture</code> events are fired, <code>click</code> should be fired before <code>lostpointercapture</code>.</p>
             <p>When the <a>pointer capture target override</a> is removed from its <code>ownerDocument</code>'s tree,
 clear the <a>pending pointer capture target override</a> and <a>pointer capture target override</a> nodes

--- a/index.html
+++ b/index.html
@@ -861,6 +861,10 @@ partial interface Navigator {
         <section>
             <h3>Implicit Release of Pointer Capture</h3>
             <p>Immediately after firing the <code>pointerup</code> or <code>pointercancel</code> events, a user agent MUST clear the <a>pending pointer capture target override</a> for the <code>pointerId</code> of the <code>pointerup</code> or <code>pointercancel</code> event that was just dispatched, and then run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps to fire <code>lostpointercapture</code> if necessary.</p>
+            <p>Immediately before firing <code>dragstart</code> event [[!HTML]],
+a user agent MUST clear the <a>pending pointer capture target override</a> for the pointer that caused the drag operation,
+and then run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps to fire <code>lostpointercapture</code>
+before the <code>dragstart</code> event if necessary.</p>
             <p>If the user agent supports firing the <code>click</code> event (see <a title="compatibility mouse events" href="#dfn-compatibility-mouse-events">compatibility mouse events</a>) and if in an implicit release scenario both <code>click</code> and <code>lostpointercapture</code> events are fired, <code>click</code> should be fired before <code>lostpointercapture</code>.</p>
             <p>When the <a>pointer capture target override</a> is removed from its <code>ownerDocument</code>'s tree, clear the <a>pending pointer capture target override</a> and <a>pointer capture target override</a> nodes and fire a PointerEvent named <code>lostpointercapture</code> at the document.</p>
         </section>

--- a/index.html
+++ b/index.html
@@ -868,7 +868,9 @@ This <code>pointercancel</code> will follow the paragraph above regarding releas
 (e.g. calling <code<preventDefault</code> the <code>dragstart</code> event)
 there will be no need for the <code>pointercancel</code>.</div>
             <p>If the user agent supports firing the <code>click</code> event (see <a title="compatibility mouse events" href="#dfn-compatibility-mouse-events">compatibility mouse events</a>) and if in an implicit release scenario both <code>click</code> and <code>lostpointercapture</code> events are fired, <code>click</code> should be fired before <code>lostpointercapture</code>.</p>
-            <p>When the <a>pointer capture target override</a> is removed from its <code>ownerDocument</code>'s tree, clear the <a>pending pointer capture target override</a> and <a>pointer capture target override</a> nodes and fire a PointerEvent named <code>lostpointercapture</code> at the document.</p>
+            <p>When the <a>pointer capture target override</a> is removed from its <code>ownerDocument</code>'s tree,
+clear the <a>pending pointer capture target override</a> and <a>pointer capture target override</a> nodes
+and fire a PointerEvent named <code>lostpointercapture</code> corresponding to the captured pointer at the document.</p>
         </section>
     </section>
     <section>


### PR DESCRIPTION
Release the pointer capture right before
the drag operation starts. In other words,
if a capturing pointer caused the drag,
before the dragstart event is fired to the page
lostpointercapture event should be sent for
that pointer.
fixes #205  and #194