### PR TITLE
GlobalEventHandlers is a mixin

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@ partial interface Element {
         <div>
             <p>The following section describes extensions to the existing <dfn><code>GlobalEventHandlers</code></dfn> interface, defined in [[!HTML5]], to facilitate the event handler registration.</p>
             <pre class="idl">
-partial interface GlobalEventHandlers {
+partial interface mixin GlobalEventHandlers {
     attribute EventHandler ongotpointercapture;
     attribute EventHandler onlostpointercapture;
     attribute EventHandler onpointerdown;


### PR DESCRIPTION
[GlobalEventHandlers](https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers) is now an `interface mixin`, so extensions should use [`partial interface mixin`](https://heycam.github.io/webidl/#partial-interface-mixin).