### PR TITLE
Clarify coalesce events and predicted event's target 

### DIFF
--- a/extension.html
+++ b/extension.html
@@ -154,8 +154,7 @@ So the first event will have the smallest <code>timeStamp</code> which should st
               </dd>
 
               <p>
-              A <a href="pointerevents2#pointerevent-interface">PointerEvent</a>'s <a href="https://dom.spec.whatwg.org/#get-target"><code> get target </code></a> algorithm, returns the associate dispatched event's target if it is a non-dispatch event (not being dispatched to a target, i.e. coalesced events
-                and predicted events); otherwise returns the object that the event is targeted using <a href="https://www.w3.org/TR/uievents/#event-flow">Event dispatch and DOM event flow</a>.
+              Coalesced events and predicted events' <a href="https://dom.spec.whatwg.org/#get-target"><code> get target </code></a> algorithm,  if associated dispatched event is not null, return the associated event's <a href="http://dom.spec.whatwg.org/#event-target"><code>target</code></a>; otherwise, returns this event's target.
               </p>
           </dl>
       </div>

--- a/extension.html
+++ b/extension.html
@@ -183,8 +183,8 @@ partial interface PointerEvent {
             boolean. When an event is created the attribute must be initialized to false.</p>
             <p> A <a> PointerEvent</a> has an associated <dfn> predicted events targets dirty</dfn>
             boolean. When an event is created the attribute must be initialized to false.</p>
-            <p> When <a>PointerEvent</a>'s target change, set both <code> coalesced event targets
-              dirty</code> and <code> predicted events targets dirty</code> to true.</p>
+            <p> When <a>PointerEvent</a>'s target is changed, set both <code> coalesced event
+              targets dirty</code> and <code> predicted events targets dirty</code> to true.</p>
 
 
               <dt><dfn>getCoalescedEvents</dfn></dt>

--- a/extension.html
+++ b/extension.html
@@ -152,6 +152,11 @@ The rest of the attributes might be different from the dispatched event based on
 The events in the sequence will have increasing <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a> ([[!WHATWG-DOM]]).
 So the first event will have the smallest <code>timeStamp</code> which should still be greater than the last event in the coalesced events.</p>
               </dd>
+
+              <p>
+                A <code>PointerEvent</code>'s <code> get target </code> algorithm, returns the associate dispatched event's target if it is a non-dispatch event (not being dispatched to a target, i.e. coalesced events
+                and predicted events); otherwise returns the object that the event is targeted using <a href="https://www.w3.org/TR/uievents/#event-flow">Event dispatch and DOM event flow</a>.
+              </p>
           </dl>
       </div>
     </section>

--- a/extension.html
+++ b/extension.html
@@ -154,7 +154,7 @@ So the first event will have the smallest <code>timeStamp</code> which should st
               </dd>
 
               <p>
-                A <code>PointerEvent</code>'s <code> get target </code> algorithm, returns the associate dispatched event's target if it is a non-dispatch event (not being dispatched to a target, i.e. coalesced events
+              A <a href="pointerevents2#pointerevent-interface">PointerEvent</a>'s <a href="https://dom.spec.whatwg.org/#get-target"><code> get target </code></a> algorithm, returns the associate dispatched event's target if it is a non-dispatch event (not being dispatched to a target, i.e. coalesced events
                 and predicted events); otherwise returns the object that the event is targeted using <a href="https://www.w3.org/TR/uievents/#event-flow">Event dispatch and DOM event flow</a>.
               </p>
           </dl>

--- a/extension.html
+++ b/extension.html
@@ -117,45 +117,74 @@ partial interface PointerEvent {
 };
           </pre>
           <dl data-dfn-for="PointerEvent" data-link-for="PointerEvent">
+            <p>A <a>PointerEvent</a> has an associated <dfn> coalesced event list</dfn> (a list of zero or more <code>PointerEvents</code>).
+            If this event is a <code>pointermove</code> or <code>pointerrawupdate</code> event, it is a sequence of all <code> PointerEvents</code> that were coasesced into this event;
+            otherwise it is the empty list. </p>
+            <p> When a <var>PointerEvent</var> is created, run the following steps for each <var>event</var> in the <a> coalesced event list</a>:
+              <ol>
+                <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code> to
+                  the <var>PointerEvent</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code>.</li>
+                <li><p>Set <var>event</var>'s <code>cancelable</code> and <code>bubbles</code> attributes to false.</li>
+                <li><p>Set <var>event</var>'s <a>coalesced event list</a> and <a> predicted event list</a> to empty list.</li>
+                <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.</li>
+              </ol>
+              The events in the sequence will have increasing <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a> ([[!WHATWG-DOM]]).
+              So the first event will have the smallest <code>timeStamp</code>.
+            </p>
+            <div class="note">
+              The PointerEvent's attributes will be initalized in a way that is best representative of all event in the coalesced event list.
+              For example its <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementX">movementX</a> and
+              <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementY">movementY</a> ([[!POINTERLOCK]])
+              COULD be the sum of those of all the coalesced events.
+            </div>
+
+            <p>A <a>PointerEvent</a> has an associated <dfn> predicted event list</dfn> (a list of zero or more <code>PointerEvents</code>).
+            If this event is a <code>pointermove</code> event, it is a sequence of <code>PointerEvents</code> the user agent predicts that will
+            follow the events in <a>coalesced event list</a> in the future; Otherwise it is the empty list.
+            The number of events in the list and how far they are from the current timestamp are determined by the user agent and the prediction algorithm it uses.
+            </p>
+
+            <p> When a <var>PointerEvent</var> is created, run the following steps for each <var>event</var> in the <a> predicted event list</a>:
+              <ol>
+                <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code> to
+                  the <var>PointerEvent</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code>.</li>
+                <li><p>Set <var>event</var>'s <code>cancelable</code> and <code>bubbles</code> attributes to false.</li>
+                <li><p>Set <var>event</var>'s <a>coalesced event list</a> and <a> predicted event list</a> to empty list.</li>
+                <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.</li>
+              </ol>
+              The events in the sequence will have increasing <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a> ([[!WHATWG-DOM]]).
+              So the first event will have the smallest <code>timeStamp</code> which should still be greater than the last event in the <a>coalesced event list</a>.</p>
+            </p>
+
+            <p> A <a> PointerEvent</a> has an associated <dfn> coalesced events targets dirty</dfn> boolean. When an event is created the attribute must be initialized to true.</p>
+            <p> A <a> PointerEvent</a> has an associated <dfn> predicted events targets dirty</dfn> boolean. When an event is created the attribute must be initialized to true.</p>
+
+
               <dt><dfn>getCoalescedEvents</dfn></dt>
               <dd>
-                  <p>Returns a sequence of all <code>PointerEvents</code> that were coalesced into the dispatched <code>pointermove</code> or <code>pointerrawupdate</code> event.
-When the event is created by the user agent the following attributes of the coalesced events will always have the same value as the dispatched event:
-<code>pointerId</code>, <code>pointerType</code>, <code>isPrimary</code>, <code>isTrusted</code>, <code>target</code>.
-Also since these coalesced events are not going to be dispatched by themselves their <code>cancelable</code> and <code>bubbles</code> attributes are false.
-In addition to that, the other attibutes related to the <a href="https://www.w3.org/TR/uievents/#event-flow">event dispatch algorithm</a>
-(e.g. <code>currentTarget</code>, <code>eventPhase</code>) will have their default value
-and the related functions (e.g. <code>stopPropagation</code>, <code>stopImmediatePropagation</code>) will do nothing.
-Note that this rule doesn't apply to <code>target</code> and it should still be the same as the dispatched event's <code>target</code>.
-This guarantees the attributes like <code>offsetX</code>, <code>offsetY</code> ([[!CSSOM-VIEW]]) which are commonly used by drawing applications to be calculated correctly for the coalesced events.
-The rest of the attributes might be different from the dispatched event.
-The events in the sequence will have increasing <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a> ([[!WHATWG-DOM]]).
-So the first event will have the smallest <code>timeStamp</code>.
-The dispatched event's attributes will be initalized in a way that is best representative of all the coalesced events.
-For example its <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementX">movementX</a> and <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementY">movementY</a> ([[!POINTERLOCK]]) COULD be the sum of those of all the coalesced events.
-None of the events in the sequence will have (nested) coalesced events, so <code>getCoalescedEvents</code> returns an empty sequence for them.
-This API always returns at least one coalesced event for <code>pointermove</code> and <code>pointerrawupdate</code> events and an empty list for other types of <code>PointerEvents</code>.</p>
-              </dd>
-              <dt><dfn>getPredictedEvents</dfn></dt>
-               <dd>
-                  <p>Returns a sequence of <code>PointerEvents</code> the user agent predicts that will follow the sequence of coalesced events in <code>pointermove</code> event in the future.
-The number of events returned by this API and how far they are from the current timestamp are determined by the user agent and the prediction algorithm it uses.
-This API always returns an empty list for pointerevent types other than <code>pointermove</code>.
-Similar to the coalesced events the following attributes of the predicted events will always have the same value as the dispatched event:
-<code>pointerId</code>, <code>pointerType</code>, <code>isPrimary</code>, <code>isTrusted</code>, <code>target</code>.
-Also <code>cancelable</code> and <code>bubbles</code> attributes will be false and other attibutes related to the <a href="https://www.w3.org/TR/uievents/#event-flow">event dispatch algorithm</a>
-(e.g. <code>currentTarget</code>, <code>eventPhase</code>) will have their default value
-and the related functions (e.g. <code>stopPropagation</code>, <code>stopImmediatePropagation</code>) will do nothing.
-Note that since the <code>target</code> of the predicted events is the same as the dispatched event's <code>target</code>,
-the attributes like <code>offsetX</code>, <code>offsetY</code> ([[!CSSOM-VIEW]]) which are commonly used by drawing applications will be calculated correctly for the predicted events.
-The rest of the attributes might be different from the dispatched event based on the prediction algorithm in user agent.
-The events in the sequence will have increasing <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a> ([[!WHATWG-DOM]]).
-So the first event will have the smallest <code>timeStamp</code> which should still be greater than the last event in the coalesced events.</p>
+              <p> <a> coalesced event list</a>'s getter, when invoked, must run these steps:
+              <ol>
+                <li> If the <a>coalesced events targets dirty</a> is true:
+                  for each event in the <a> coalesced event list</a>, set the
+                  event's <a href="https://dom.spec.whatwg.org/#event-target"><code>target</code></a> to this <code>PointerEvent</code>'s target.
+                <li> Set the <a> coalesced events targets dirty</a> to false.
+                <li> Return the <a> coalesced event list </a>
+              </ol>
+              </p>
               </dd>
 
-              <p>
-              Coalesced events and predicted events' <a href="https://dom.spec.whatwg.org/#get-target"><code> get target </code></a> algorithm,  if associated dispatched event is not null, return the associated event's <a href="http://dom.spec.whatwg.org/#event-target"><code>target</code></a>; otherwise, returns this event's target.
+              <dt><dfn>getPredictedEvents</dfn></dt>
+              <dd>
+              <p> <a> predicted event list</a>'s getter, when invoked, must run these steps:
+              <ol>
+                <li> If the <a>predicted events targets dirty</a> is true:
+                  for each event in the <a> coalesced event list</a>, set the
+                  event's <a href="https://dom.spec.whatwg.org/#event-target"><code>target</code></a> to this <code>PointerEvent</code>'s target.
+                <li> Set the <a> predicted events targets dirty</a> to false.
+                <li> Return the <a> predicted event list </a>
+              </ol>
               </p>
+              </dd>
           </dl>
       </div>
     </section>

--- a/extension.html
+++ b/extension.html
@@ -117,60 +117,88 @@ partial interface PointerEvent {
 };
           </pre>
           <dl data-dfn-for="PointerEvent" data-link-for="PointerEvent">
-            <p>A <a>PointerEvent</a> has an associated <dfn> coalesced event list</dfn> (a list of zero or more <code>PointerEvents</code>).
-            If this event is a <code>pointermove</code> or <code>pointerrawupdate</code> event, it is a sequence of all <code> PointerEvents</code> that were coasesced into this event;
-            otherwise it is the empty list. </p>
-            <p> When a <var>PointerEvent</var> is created, run the following steps for each <var>event</var> in the <a> coalesced event list</a>:
+            <p>A <a>PointerEvent</a> has an associated <dfn> coalesced event list</dfn> (a list of
+            zero or more <code>PointerEvents</code>). If this event is a <code>pointermove</code>
+            or <code>pointerrawupdate</code> event, it is a sequence of all <code> PointerEvent
+            </code> that were coasesced into this event; otherwise it is the empty list.</p>
+            <p>The events in the <code >coalesced event list </code> will have increasing
+            <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a>
+            ([[!WHATWG-DOM]]), so the first event will have the smallest <code>timeStamp</code>.
+            </p>
+
+            <p> When a <var>PointerEvent</var> is created, run the following steps for each
+            <var>event</var> in the <a> coalesced event list</a>:
               <ol>
-                <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code> to
-                  the <var>PointerEvent</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code>.</li>
-                <li><p>Set <var>event</var>'s <code>cancelable</code> and <code>bubbles</code> attributes to false.</li>
-                <li><p>Set <var>event</var>'s <a>coalesced event list</a> and <a> predicted event list</a> to empty list.</li>
-                <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.</li>
+                <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>,
+                  <code>isPrimary</code> and <code>isTrusted</code> to the <var>PointerEvent</var>'s
+                  <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and
+                  <code>isTrusted</code>.</li>
+                <li><p>Set <var>event</var>'s <code>cancelable</code> and <code>bubbles</code>
+                  attributes to false.</li>
+                <li><p>Set <var>event</var>'s <a>coalesced event list</a> and <a> predicted event
+                    list</a> to empty list.</li>
+                <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.
               </ol>
-              The events in the sequence will have increasing <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a> ([[!WHATWG-DOM]]).
-              So the first event will have the smallest <code>timeStamp</code>.
             </p>
             <div class="note">
-              The PointerEvent's attributes will be initalized in a way that is best representative of all event in the coalesced event list.
-              For example its <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementX">movementX</a> and
-              <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementY">movementY</a> ([[!POINTERLOCK]])
-              COULD be the sum of those of all the coalesced events.
+              The PointerEvent's attributes will be initalized in a way that is best representative
+              of all event in the coalesced event list.
+              For example its <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementX">
+                movementX</a> and
+              <a href="https://www.w3.org/TR/pointerlock/#widl-MouseEvent-movementY">movementY</a>
+              ([[!POINTERLOCK]]) COULD be the sum of those of all the coalesced events.
             </div>
 
-            <p>A <a>PointerEvent</a> has an associated <dfn> predicted event list</dfn> (a list of zero or more <code>PointerEvents</code>).
-            If this event is a <code>pointermove</code> event, it is a sequence of <code>PointerEvents</code> the user agent predicts that will
-            follow the events in <a>coalesced event list</a> in the future; Otherwise it is the empty list.
-            The number of events in the list and how far they are from the current timestamp are determined by the user agent and the prediction algorithm it uses.
+            <p>A <a>PointerEvent</a> has an associated <dfn> predicted event list</dfn> (a list of
+            zero or more <code>PointerEvents</code>). If this event is a <code>pointermove</code>
+            event, it is a sequence of <code>PointerEvents</code> the user agent predicts that will
+            follow the events in <a>coalesced event list</a> in the future; otherwise it is the
+            empty list.
+            The number of events in the list and how far they are from the current timestamp are
+            determined by the user agent and the prediction algorithm it uses.</p>
+
+            <p>The events in the <code> predicted event list</code> will have increasing
+            <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a>
+            ([[!WHATWG-DOM]]), so the first event will have the smallest <code>timeStamp</code>
+            which should still be greater than the last event in the <a>coalesced event list</a>.
             </p>
 
-            <p> When a <var>PointerEvent</var> is created, run the following steps for each <var>event</var> in the <a> predicted event list</a>:
+            <p> When a <var>PointerEvent</var> is created, run the following steps for each
+            <var>event</var> in the <a> predicted event list</a>:
               <ol>
-                <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code> to
-                  the <var>PointerEvent</var>'s <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and <code>isTrusted</code>.</li>
-                <li><p>Set <var>event</var>'s <code>cancelable</code> and <code>bubbles</code> attributes to false.</li>
-                <li><p>Set <var>event</var>'s <a>coalesced event list</a> and <a> predicted event list</a> to empty list.</li>
-                <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.</li>
+                <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>,
+                  <code>isPrimary</code> and <code>isTrusted</code> to the <var>PointerEvent</var>'s
+                  <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and
+                  <code>isTrusted</code>.</li>
+                <li><p>Set <var>event</var>'s <code>cancelable</code> and <code>bubbles</code>
+                  attributes to false.</li>
+                <li><p>Set <var>event</var>'s <a>coalesced event list</a> and <a> predicted event
+                    list</a> to empty list.</li>
+                <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.
               </ol>
-              The events in the sequence will have increasing <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a> ([[!WHATWG-DOM]]).
-              So the first event will have the smallest <code>timeStamp</code> which should still be greater than the last event in the <a>coalesced event list</a>.</p>
+            </p>
             </p>
 
-            <p> A <a> PointerEvent</a> has an associated <dfn> coalesced events targets dirty</dfn> boolean. When an event is created the attribute must be initialized to true.</p>
-            <p> A <a> PointerEvent</a> has an associated <dfn> predicted events targets dirty</dfn> boolean. When an event is created the attribute must be initialized to true.</p>
+            <p> A <a> PointerEvent</a> has an associated <dfn> coalesced events targets dirty</dfn>
+            boolean. When an event is created the attribute must be initialized to false.</p>
+            <p> A <a> PointerEvent</a> has an associated <dfn> predicted events targets dirty</dfn>
+            boolean. When an event is created the attribute must be initialized to false.</p>
+            <p> When <a>PointerEvent</a>'s target change, set both <code> coalesced event targets
+              dirty</code> and <code> predicted events targets dirty</code> to true.</p>
 
 
               <dt><dfn>getCoalescedEvents</dfn></dt>
               <dd>
-              <p> <a> coalesced event list</a>'s getter, when invoked, must run these steps:
-              <ol>
-                <li> If the <a>coalesced events targets dirty</a> is true:
-                  for each event in the <a> coalesced event list</a>, set the
-                  event's <a href="https://dom.spec.whatwg.org/#event-target"><code>target</code></a> to this <code>PointerEvent</code>'s target.
-                <li> Set the <a> coalesced events targets dirty</a> to false.
-                <li> Return the <a> coalesced event list </a>
-              </ol>
-              </p>
+                <p> <a> coalesced event list</a>'s getter, when invoked, must run these steps:
+                <ol>
+                  <li> If the <a>coalesced events targets dirty</a> is true:
+                    for each event in the <a> coalesced event list</a>, set the event's
+                    <a href="https://dom.spec.whatwg.org/#event-target"><code>target</code></a>
+                    to this <code>PointerEvent</code>'s target.
+                  <li> Set the <a> coalesced events targets dirty</a> to false.
+                  <li> Return the <a> coalesced event list </a>
+                </ol>
+                </p>
               </dd>
 
               <dt><dfn>getPredictedEvents</dfn></dt>

--- a/extension.html
+++ b/extension.html
@@ -117,28 +117,13 @@ partial interface PointerEvent {
 };
           </pre>
           <dl data-dfn-for="PointerEvent" data-link-for="PointerEvent">
-            <p>A <a>PointerEvent</a> has an associated <dfn> coalesced event list</dfn> (a list of
+            <p>A <a>PointerEvent</a> has an associated <dfn>coalesced event list</dfn> (a list of
             zero or more <code>PointerEvents</code>). If this event is a <code>pointermove</code>
             or <code>pointerrawupdate</code> event, it is a sequence of all <code> PointerEvent
             </code> that were coasesced into this event; otherwise it is the empty list.</p>
             <p>The events in the <code >coalesced event list </code> will have increasing
             <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a>
             ([[!WHATWG-DOM]]), so the first event will have the smallest <code>timeStamp</code>.
-            </p>
-
-            <p> When a <var>PointerEvent</var> is created, run the following steps for each
-            <var>event</var> in the <a> coalesced event list</a>:
-              <ol>
-                <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>,
-                  <code>isPrimary</code> and <code>isTrusted</code> to the <var>PointerEvent</var>'s
-                  <code>pointerId</code>, <code> pointerType</code>, <code>isPrimary</code> and
-                  <code>isTrusted</code>.</li>
-                <li><p>Set <var>event</var>'s <code>cancelable</code> and <code>bubbles</code>
-                  attributes to false.</li>
-                <li><p>Set <var>event</var>'s <a>coalesced event list</a> and <a> predicted event
-                    list</a> to empty list.</li>
-                <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.
-              </ol>
             </p>
             <div class="note">
               The PointerEvent's attributes will be initalized in a way that is best representative
@@ -149,7 +134,7 @@ partial interface PointerEvent {
               ([[!POINTERLOCK]]) COULD be the sum of those of all the coalesced events.
             </div>
 
-            <p>A <a>PointerEvent</a> has an associated <dfn> predicted event list</dfn> (a list of
+            <p>A <a>PointerEvent</a> has an associated <dfn>predicted event list</dfn> (a list of
             zero or more <code>PointerEvents</code>). If this event is a <code>pointermove</code>
             event, it is a sequence of <code>PointerEvents</code> the user agent predicts that will
             follow the events in <a>coalesced event list</a> in the future; otherwise it is the
@@ -164,7 +149,7 @@ partial interface PointerEvent {
             </p>
 
             <p> When a <var>PointerEvent</var> is created, run the following steps for each
-            <var>event</var> in the <a> predicted event list</a>:
+            <var>event</var> in the <a> coalesced event list</a> and <a>predicted event list</a>:
               <ol>
                 <li><p>Set <var>event</var>'s <code>pointerId</code>, <code> pointerType</code>,
                   <code>isPrimary</code> and <code>isTrusted</code> to the <var>PointerEvent</var>'s
@@ -177,14 +162,13 @@ partial interface PointerEvent {
                 <li><p> Initialize the rest of the attributes the same way as <a>PointerEvent</a>.
               </ol>
             </p>
-            </p>
 
-            <p> A <a> PointerEvent</a> has an associated <dfn> coalesced events targets dirty</dfn>
-            boolean. When an event is created the attribute must be initialized to false.</p>
-            <p> A <a> PointerEvent</a> has an associated <dfn> predicted events targets dirty</dfn>
-            boolean. When an event is created the attribute must be initialized to false.</p>
-            <p> When <a>PointerEvent</a>'s target is changed, set both <code> coalesced event
-              targets dirty</code> and <code> predicted events targets dirty</code> to true.</p>
+            <p> A <a> PointerEvent</a> has an associated <dfn>coalesced events targets dirty</dfn>
+            boolean and an associated <dfn>predicted events targets dirty</dfn> boolean. When an
+            event is created they must be initialized to false.</p>
+            <p> When <a>PointerEvent</a>'s target is changed, set both <a><code>coalesced events
+            targets dirty</code></a> and <a><code>predicted events targets dirty</code></a> to true.
+            </p>
 
 
               <dt><dfn>getCoalescedEvents</dfn></dt>
@@ -203,13 +187,14 @@ partial interface PointerEvent {
 
               <dt><dfn>getPredictedEvents</dfn></dt>
               <dd>
-              <p> <a> predicted event list</a>'s getter, when invoked, must run these steps:
+              <p> <a>predicted event list</a>'s getter, when invoked, must run these steps:
               <ol>
                 <li> If the <a>predicted events targets dirty</a> is true:
-                  for each event in the <a> coalesced event list</a>, set the
-                  event's <a href="https://dom.spec.whatwg.org/#event-target"><code>target</code></a> to this <code>PointerEvent</code>'s target.
-                <li> Set the <a> predicted events targets dirty</a> to false.
-                <li> Return the <a> predicted event list </a>
+                  for each event in the <a>coalesced event list</a>, set the event's
+                  <a href="https://dom.spec.whatwg.org/#event-target"><code>target</code></a> to
+                  this <code>PointerEvent</code>'s <code>target</code>.
+                <li> Set the <a>predicted events targets dirty</a> to false.
+                <li> Return the <a>predicted event list </a>
               </ol>
               </p>
               </dd>


### PR DESCRIPTION
As the suggestion from tag review, changing the text for `target` 