### PR TITLE
Define active document for the active pointers

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,8 @@ eventTarget.dispatchEvent(event);</code>
         <dl>
             <dt><dfn>active buttons state</dfn></dt>
                 <dd>The condition when a pointer has a non-zero value for the <code>buttons</code> property. For mouse, this is when the device has at least one button depressed. For touch, this is when there is physical contact with the digitizer. For pen, this is when either the pen has physical contact with the digitizer, or at least one button is depressed while hovering.</dd>
+            <dt><dfn>active document</dfn></dt>
+                <dd>For every <a>active pointer</a>, the document that received the last event from that pointer.</dd>
             <dt><dfn>active pointer</dfn></dt>
                 <dd>Any touch contact, pen stylus, mouse cursor, or other pointer that can produce events.  If it is possible for a given pointer (identified by a unique <code>pointerId</code>) to produce additional events within the document, then that pointer is still considered active. Examples:
                     <ul>
@@ -391,17 +393,24 @@ interface PointerEvent : MouseEvent {
             <section>
                 <h2>Firing events using the <code>PointerEvent</code> interface</h2>
                 <p>To <dfn>fire a pointer event named e</dfn> means to <dfn>fire an event named e</dfn> as defined in [[!DOM4]] with an event using the <a>PointerEvent</a> interface whose attributes are set as defined in <a href="#pointerevent-interface"><code>PointerEvent</code> Interface</a> and <a href="#attributes-and-default-actions">Attributes and Default Actions</a>.</p>
-                <p>If the event is not <code>gotpointercapture</code> or <code>lostpointercapture</code>, run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps for this <code>PointerEvent</code>.
+                <p>If the <var>event</var>'s <code>type</code> is not <code>gotpointercapture</code> or <code>lostpointercapture</code>, run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps for this <code>PointerEvent</code>.
 
-                <p>The target object at which the event is fired is determined as follows:
+                <p>The <var>eventTarget</var> object at which the <var>event</var> is fired is determined as follows:
                 <ul>
-                    <li>If the <a>pointer capture target override</a> has been set for the pointer, set the target to <a>pointer capture target override</a> object.</li>
-                    <li>Otherwise, set the target to the object returned by normal hit test mechanisms (out of scope for this specification).</li>
+                    <li>If the <a>pointer capture target override</a> has been set for the pointer, set the <var>eventTarget</var> to <a>pointer capture target override</a> object.</li>
+                    <li>Otherwise, set the <var>eventTarget</var> to the object returned by normal hit test mechanisms (out of scope for this specification).</li>
                 </ul>
 
-                <p>If this is a <code>pointerdown</code> event, the associated device is a direct manipulation device and the target is an <code>Element</code>, then <a href="#setting-pointer-capture">set pointer capture</a> for this <code>pointerId</code> to the target element as described in <a>implicit pointer capture</a>.
+                <p>If the <var>eventTarget</var> is an <code>Element</code>, then let <var>targetDocument</var> be <var>eventTarget</var>'s <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a> [[!DOM4]].
+                   Otherwise, <var>eventTarget</var> is a <code>Window</code> object,
+                   let <var>targetDocument</var> be <var>eventTarget</var>'s <a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">associated Document</a> [[!DOM4]].</p>
 
-                <p>Fire the event to the determined target.
+                <p>If the <var>event</var> is <code>pointerdown</code>, <code>pointermove</code>, or <code>pointerup</code> set <a>active document</a> for the <var>event</var>'s <code>pointerId</code> to <var>targetDocument</var>.</p>
+
+                <p>If the <var>event</var> is <code>pointerdown</code> event, the associated device is a direct manipulation device and the <var>eventTarget</var> is an <code>Element</code>,
+                   then <a href="#setting-pointer-capture">set pointer capture</a> for this <code>pointerId</code> to the <var>eventTarget</var> element as described in <a>implicit pointer capture</a>.
+
+                <p>Fire the <var>event</var> to the determined <var>eventTarget</var>.
 
                 <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events. This is the same as the pointer leaving its previous target and entering this new capturing target - and if they are different targets, boundary events should be dispatched first. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>
 
@@ -799,12 +808,16 @@ partial interface Navigator {
         </section>
         <section>
             <h2>Setting Pointer Capture</h2>
-            <p>Pointer capture is set on an element by calling the <code>element.setPointerCapture(pointerId)</code> method. When this method is invoked, a user agent MUST run the following steps:</p>
+            <p>Pointer capture is set on an <var>element</var> of type <code>Element</code> by calling the <code>element.setPointerCapture(pointerId)</code> method.
+               When this method is invoked, a user agent MUST run the following steps:</p>
             <ol>
                 <li>If the <code>pointerId</code> provided as the method's argument does not match any of the <a data-lt="active pointer">active pointers</a>, then throw a <code>DOMException</code> with the name <code>NotFoundError</code>.</li>
-                <li>If the <code>Element</code> on which this method is invoked is not <a href="https://dom.spec.whatwg.org/#connected"><code>connected</code></a> ([[!DOM4]]), throw an exception with the name <code>InvalidStateError</code>.</li>
-                <li>If this method is invoked while the document has a locked element ([[!PointerLock]]), throw an exception with the name <code>InvalidStateError</code>.</li>
-                <li>If the pointer is not in the <a>active buttons state</a>, then terminate these steps.</li>
+                <li>Let the <var>pointer</var> be the <a>active pointer</a> specified by the given <code>pointerId</code>.
+                <li>If the <var>element</var> is not <a href="https://dom.spec.whatwg.org/#connected"><code>connected</code></a> ([[!DOM4]]), throw an exception with the name <code>InvalidStateError</code>.</li>
+                <li>If this method is invoked while the <var>element</var>'s <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a> [[!DOM4]] has a locked element ([[!PointerLock]]),
+                    throw an exception with the name <code>InvalidStateError</code>.</li>
+                <li>If the <var>pointer</var> is not in the <a>active buttons state</a> or
+                    the <var>element</var>'s <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a> [[!DOM4]] is not the <a>active document</a> of the <var>pointer</var>, then terminate these steps.</li>
                 <li>For the specified <code>pointerId</code>, set the <dfn>pending pointer capture target override</dfn> to the <code>Element</code> on which this method was invoked.</li>
             </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -393,24 +393,22 @@ interface PointerEvent : MouseEvent {
             <section>
                 <h2>Firing events using the <code>PointerEvent</code> interface</h2>
                 <p>To <dfn>fire a pointer event named e</dfn> means to <dfn>fire an event named e</dfn> as defined in [[!DOM4]] with an event using the <a>PointerEvent</a> interface whose attributes are set as defined in <a href="#pointerevent-interface"><code>PointerEvent</code> Interface</a> and <a href="#attributes-and-default-actions">Attributes and Default Actions</a>.</p>
-                <p>If the <var>event</var>'s <code>type</code> is not <code>gotpointercapture</code> or <code>lostpointercapture</code>, run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps for this <code>PointerEvent</code>.
+                <p>If the event is not <code>gotpointercapture</code> or <code>lostpointercapture</code>, run <a href="#process-pending-pointer-capture">Process Pending Pointer Capture</a> steps for this <code>PointerEvent</code>.
 
-                <p>The <var>eventTarget</var> object at which the <var>event</var> is fired is determined as follows:
+                <p>The target object at which the event is fired is determined as follows:
                 <ul>
-                    <li>If the <a>pointer capture target override</a> has been set for the pointer, set the <var>eventTarget</var> to <a>pointer capture target override</a> object.</li>
-                    <li>Otherwise, set the <var>eventTarget</var> to the object returned by normal hit test mechanisms (out of scope for this specification).</li>
+                    <li>If the <a>pointer capture target override</a> has been set for the pointer, set the target to <a>pointer capture target override</a> object.</li>
+                    <li>Otherwise, set the target to the object returned by normal hit test mechanisms (out of scope for this specification).</li>
                 </ul>
 
-                <p>If the <var>eventTarget</var> is an <code>Element</code>, then let <var>targetDocument</var> be <var>eventTarget</var>'s <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a> [[!DOM4]].
-                   Otherwise, <var>eventTarget</var> is a <code>Window</code> object,
-                   let <var>targetDocument</var> be <var>eventTarget</var>'s <a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">associated Document</a> [[!DOM4]].</p>
+                <p>Let <var>targetDocument</var> be target's <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a> [[!DOM4]].
 
-                <p>If the <var>event</var> is <code>pointerdown</code>, <code>pointermove</code>, or <code>pointerup</code> set <a>active document</a> for the <var>event</var>'s <code>pointerId</code> to <var>targetDocument</var>.</p>
+                <p>If the event is <code>pointerdown</code>, <code>pointermove</code>, or <code>pointerup</code> set <a>active document</a> for the event's <code>pointerId</code> to <var>targetDocument</var>.</p>
 
-                <p>If the <var>event</var> is <code>pointerdown</code> event, the associated device is a direct manipulation device and the <var>eventTarget</var> is an <code>Element</code>,
-                   then <a href="#setting-pointer-capture">set pointer capture</a> for this <code>pointerId</code> to the <var>eventTarget</var> element as described in <a>implicit pointer capture</a>.
+                <p>If the event is <code>pointerdown</code> event, the associated device is a direct manipulation device and the target is an <code>Element</code>,
+                   then <a href="#setting-pointer-capture">set pointer capture</a> for this <code>pointerId</code> to the target element as described in <a>implicit pointer capture</a>.
 
-                <p>Fire the <var>event</var> to the determined <var>eventTarget</var>.
+                <p>Fire the event to the determined target.
 
                 <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events. This is the same as the pointer leaving its previous target and entering this new capturing target - and if they are different targets, boundary events should be dispatched first. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>
 


### PR DESCRIPTION
Limit the pointer capture API scope to only work
when it is called on the document who got the
last event in the given pointer stream.

Fixes #291


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 4, 2019, 9:35 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fpointerevents%2F506fdd165b523f5b2cf02402ffa63812cce3e10d%2Findex.html%3FisPreview%3Dtrue)

```
[33m📡 HTTP Error 520:[39m [36mhttps://rawcdn.githack.com/w3c/pointerevents/506fdd165b523f5b2cf02402ffa63812cce3e10d/index.html[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/pointerevents%23300.)._
</details>
