### PR TITLE
Prevent the [[CSSOM-VIEW]] reference from pulling its internal references

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@ interface PointerEvent : MouseEvent {
                         </dd>
                 </dl>
 
-                <p>The <dfn><code>PointerEventInit</code></dfn> dictionary is used by the <dfn><code>PointerEvent</code></dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the <code>MouseEventInit</code> dictionary defined in [[UI-EVENTS]]. The steps for constructing an event are defined in [[DOM]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
+                <p>The <dfn><code>PointerEventInit</code></dfn> dictionary is used by the <dfn><code>PointerEvent</code></dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UI-EVENTS]]. The steps for constructing an event are defined in [[DOM]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
 
                 <p>A <a>PointerEvent</a> has an associated <dfn>coalesced event list</dfn> (a list of
                 zero or more <code>PointerEvents</code>). If this event is a <code>pointermove</code>
@@ -490,7 +490,7 @@ interface PointerEvent : MouseEvent {
                 <p>When the <a>PointerEvent</a>'s target is changed, set <a><code>coalesced events
                 targets dirty</code></a> and <a><code>predicted events targets dirty</code></a> to true.</p>
 
-                <div class="note">The <code>PointerEvent</code> interface inherits from <code>MouseEvent</code>, defined in [[UIEVENTS]] and extended by [[CSSOM-VIEW]].</div>
+                <div class="note">The <code>PointerEvent</code> interface inherits from <code>MouseEvent</code>, defined in [[UIEVENTS]] and extended by [[[CSSOM-VIEW]]].</div>
             </div>
             <section>
                 <h2>Button States</h2>


### PR DESCRIPTION
ok. This is a slight change since the note will directly link to CSSOM View spec instead of linking to the informative references section, but it does make respec stop loading the "cssom-view" internal references within the section, thus preventing the ambiguity of ui-events/MouseEventInit

Fyi for @marcoscaceres , we have a div.note that cites "[[CSSOM-VIEW]]", thus triggering the load of all internal references for cssom-view within the section. Any attempts to disambiguate using data-cite="ui-events" (for pre.idl or for {{MouseEventInit}}) within that section fails.

Fix #311


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/313.html" title="Last updated on Nov 30, 2019, 5:26 PM UTC (4509d21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/313/011270e...4509d21.html" title="Last updated on Nov 30, 2019, 5:26 PM UTC (4509d21)">Diff</a>