### PR TITLE
Add secure context criteria to pointerrawupdate and getCoalescedEvents

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@ interface PointerEvent : MouseEvent {
     readonly        attribute long        twist;
     readonly        attribute DOMString   pointerType;
     readonly        attribute boolean     isPrimary;
-    sequence&lt;PointerEvent> getCoalescedEvents();
+    [SecureContext] sequence&lt;PointerEvent> getCoalescedEvents();
     sequence&lt;PointerEvent> getPredictedEvents();
 };
               </pre>
@@ -822,6 +822,7 @@ partial interface mixin GlobalEventHandlers {
     attribute EventHandler onlostpointercapture;
     attribute EventHandler onpointerdown;
     attribute EventHandler onpointermove;
+    [SecureContext] attribute EventHandler onpointerrawupdate;
     attribute EventHandler onpointerup;
     attribute EventHandler onpointercancel;
     attribute EventHandler onpointerover;

--- a/index.html
+++ b/index.html
@@ -696,8 +696,8 @@ interface PointerEvent : MouseEvent {
             <section>
                 <h3>The <dfn><code>pointerrawupdate</code> event</dfn></h3>
                 <p>A user agent MUST <a href="https://w3c.github.io/pointerevents/index.html#firing-events-using-the-pointerevent-interface">fire a pointer event</a>
-                named <code>pointerrawupdate</code> when a pointing device attribute
-                (i.e. button state, coordinates, pressure, tangential pressure, tilt, twist, or contact geometry) is changed.
+                named <code>pointerrawupdate</code> only within a <a href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts">secure context</a> when
+                a pointing device attribute (i.e. button state, coordinates, pressure, tangential pressure, tilt, twist, or contact geometry) is changed.
                 As opposed to <code>pointermove</code> which might be aligned to animation callbacks,
                 user agents SHOULD dispatch <code>pointerrawupdate</code> events as soon as possible
                 and as frequent as the javascript can handle the events.


### PR DESCRIPTION
Add secure context criteria to pointerrawupdate event 
and getCoalescedEvents APIs to reduce its exposure
to possible attacks such as injecting scripts to http traffic.
closes #277


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/318.html" title="Last updated on Mar 19, 2020, 8:02 PM UTC (6f548f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/318/90ac201...6f548f8.html" title="Last updated on Mar 19, 2020, 8:02 PM UTC (6f548f8)">Diff</a>