### PR TITLE
Translate between tiltX/tiltY and azimuth/altitude. Fixes #321

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,8 +287,6 @@ dictionary PointerEventInit : MouseEventInit {
     long        tiltX = 0;
     long        tiltY = 0;
     long        twist = 0;
-    double      altitudeAngle = 0;
-    double      azimuthAngle = 0;
     DOMString   pointerType = "";
     boolean     isPrimary = false;
     sequence&lt;PointerEvent> coalescedEvents = [];
@@ -306,12 +304,14 @@ interface PointerEvent : MouseEvent {
     readonly        attribute long        tiltX;
     readonly        attribute long        tiltY;
     readonly        attribute long        twist;
-    readonly        attribute double      altitudeAngle;
-    readonly        attribute double      azimuthAngle;
     readonly        attribute DOMString   pointerType;
     readonly        attribute boolean     isPrimary;
     [SecureContext] sequence&lt;PointerEvent> getCoalescedEvents();
     sequence&lt;PointerEvent> getPredictedEvents();
+    static                    double      getAzimuthAngle(long tiltX, long tiltY);
+    static                    double      getAltitudeAngle(long tiltX, long tiltY);
+    static                    long        getTiltX(double azimuthAngle, double altitudeAngle);
+    static                    long        getTiltY(double azimuthAngle, double altitudeAngle);
 };
               </pre>
                 <dl data-dfn-for="PointerEvent" data-link-for="PointerEvent">
@@ -359,14 +359,6 @@ interface PointerEvent : MouseEvent {
                         <dd>
                             <p>The clockwise rotation (in degrees, in the range of [0,359]) of a transducer (e.g. pen stylus) around its own major axis. For hardware and platforms that do not report twist, the value MUST be 0.</p>
                         </dd>
-                    <dt><dfn>altitudeAngle</dfn></dt>
-                        <dd>
-                            <p>The altitude (in radians) of the transducer (e.g. pen stylus), in the range [0,π/2] - where 0 is parallel to the surface (X-Y plane), and π/2 is perpendicular to the surface. For hardware and platforms that do not report tilt or angle, the value MUST be 0.</p>
-                        </dd>
-                    <dt><dfn>azimuthAngle</dfn></dt>
-                        <dd>
-                            <p>The azimuth angle (in radians) of the transducer (e.g. pen stylus), in the range [0, 2π] - where 0 represents a transducer whose cap is pointing in the direction of increasing X values (point to "3 o'clock" if looking straight down) on the X-Y plane, and the values progressively increase when going clockwise (π/2 at "6 o'clock", π at "9 o'clock", 3π/2 at "12 o'clock"). When the transducer is perfectly perpendicular to the surface (<code>altitudeAngle</code> of π/2), the value MUST be 0. For hardware and platforms that do not report tilt or angle, the value MUST be 0.</p>
-                        </dd>
                     <dt><dfn>pointerType</dfn></dt>
                         <dd>
                             <p>Indicates the device type that caused the event (mouse, pen, touch, etc.). If a user agent is to <a>fire a pointer event</a> for a mouse, pen stylus, or touch input device, then the value of <code>pointerType</code> MUST be according to the following table:</p>
@@ -413,12 +405,42 @@ interface PointerEvent : MouseEvent {
                            </ol>
                            </p>
                         </dd>
+                      <dt><dfn>getAzimuthAngle</dfn> <code>(long tiltX, long tiltY)</code></dt>
+                        <dd>
+                            Return the <code>azimuthAngle</code> angle (in radians) of the transducer (e.g. pen stylus) calculated from
+                            <code>tiltX</code> and <code>tiltY</code> angles, in the range [0, 2π] - where 0 represents a transducer whose cap is pointing in the
+                            direction of increasing X values (point to "3 o'clock" if looking straight down) on the X-Y plane, and the
+                            values progressively increase when going clockwise (π/2 at "6 o'clock", π at "9 o'clock", 3π/2 at "12 o'clock").
+                            When the transducer is perfectly perpendicular to the surface (<code>tiltX</code> and <code>tiltY</code> of 0),
+                            the returned value MUST be 0.
+                        </dd>
+                      <dt><dfn>getAltitudeAngle</dfn> <code>(long tiltX, long tiltY)</code></dt>
+                        <dd>
+                            Return the <code>altitudeAngle</code> (in radians) of the transducer (e.g. pen stylus) calculated from
+                            <code>tiltX</code> and <code>tiltY</code> angles,
+                            in the range [0,π/2] - where 0 is parallel to the surface (X-Y plane),
+                            and π/2 is perpendicular to the surface.
+                        </dd>
+                      <dt><dfn>getTiltX</dfn> <code>(double azimuthAngle, double altitudeAngle)</code></dt>
+                        <dd>
+                            Return the <code>tiltX</code> angle (in degrees) calculated from <code>azimuthAngle</code> and <code>altitudeAngle</code>.
+                        </dd>
+                      <dt><dfn>getTiltY</dfn> <code>(double azimuthAngle, double altitudeAngle)</code></dt>
+                        <dd>
+                            Return the <code>tiltY</code> angle (in degrees) calculated from <code>azimuthAngle</code> and <code>altitudeAngle</code>.
+                        </dd>
+
                 </dl>
 
                 <p>The <dfn><code>PointerEventInit</code></dfn> dictionary is used by the <dfn><code>PointerEvent</code></dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UI-EVENTS]]. The steps for constructing an event are defined in [[DOM]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
 
-                <div class-"note">Pointer Events include two complementary sets of attributes to express the orientation of a transducer relative the X-Z plane: <dfn><code>tiltX</code></dfn> / <dfn><code>tiltY</code></dfn> (introduced in the original Pointer Events specification), and <dfn><code>altitudeAngle</code></dfn> / <dfn><code>azimuthAngle</code></dfn> (adopted from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).
-                    Implementations MUST support both sets of attributes. When an untrusted (synthetic) Pointer Event is created programmatically using the constructor, and only one set of values is provided, the complementary set of attributes MUST be calculated and initialized.</div>
+                <div class-"note">Two different pairs of angles can be used to express the orientation of a
+                    transducer relative the X-Y plane: <dfn><code>tiltX</code></dfn> / <dfn><code>tiltY</code></dfn>
+                    (introduced in the original Pointer Events specification), and
+                    <dfn><code>azimuthAngle</code></dfn> / <dfn><code>altitudeAngle</code></dfn>
+                    (as defined in <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).
+                    <dfn><code>PointerEvent</code></dfn> interface's static methods <code>getAzimuthAngle</code>, <code>getAltitudeAngle</code>,
+                    <code>getTiltX</code> and <code>getTiltY</code> can be used to translate between the two sets of angles.
 
                 <p>A <a>PointerEvent</a> has an associated <dfn>coalesced event list</dfn> (a list of
                 zero or more <code>PointerEvents</code>). If this event is a <code>pointermove</code>
@@ -671,7 +693,7 @@ interface PointerEvent : MouseEvent {
                     <ol>
                         <li>If the <a>pointer capture target override</a> for this pointer is set and is not equal to the <a>pending pointer capture target override</a>, then fire a pointer event named <code>lostpointercapture</code> at the <a>pointer capture target override</a> node.
                         </li>
-                        <li>If the <a>pending pointer capture target override</a> for this pointer is set and is not equal to the <a>pointer capture target override</a>, then fire a pointer event named <code>gotpointercapture</code> at the <a>pending pointer capture target override</a>. 
+                        <li>If the <a>pending pointer capture target override</a> for this pointer is set and is not equal to the <a>pointer capture target override</a>, then fire a pointer event named <code>gotpointercapture</code> at the <a>pending pointer capture target override</a>.
                         </li>
                         <li>Set the <dfn>pointer capture target override</dfn> to the <a>pending pointer capture target override</a>, if set. Otherwise, clear the <a>pointer capture target override</a>.</li>
                     </ol>
@@ -1195,7 +1217,7 @@ partial interface Navigator {
     </section>
     <section class='informative'>
         <h2>Converting between <code>tiltX</code> / <code>tiltY</code> and <code>altitudeAngle</code> / <code>azimuthAngle</code></h2>
-        <p>Depending on the specific hardware and platform, user agents will likely only receive one set of values for the transducer orientation relative to the screen plane - either <code>tiltX</code> / <code>tiltY</code> or <code>altitudeAngle</code> / <code>azimuthAngle</code>. The following basic code provides an initial suggested approach for converting these values.</p>
+        <p>The following basic code provides an initial suggested approach for converting these values.</p>
         <pre id="example_12" class="example" title="Converting between tiltX/tiltY and altitudeAngle/azimuthAngle"><code>/* Converting between tiltX/tiltY and altitudeAngle/azimuthAngle */
 
 function spherical2tilt(altitudeAngle, azimuthAngle){

--- a/index.html
+++ b/index.html
@@ -1196,7 +1196,7 @@ partial interface Navigator {
                     <li><code>mouseout</code></li>
                     <li><code>mouseleave</code></li>
                 </ol>
-                <p>If, however, the <code>pointerdown</code> event is <a data-lt="canceled event">canceled</a> during this interaction then the sequence of events would be:</p>
+                <p>If, however, the <code>pointerdown</code> event is <a data-lt="canceled event">canceled</a> during this interaction then the sequence of events would be:</p> 
                 <ol data-class="note-list">
                     <li><code>mousemove</code></li>
                     <li><code>pointerover</code></li>


### PR DESCRIPTION
Add to Pointer Events interface 4 static methods to translate between tiltX/tiltY and azimuth/altitude angles.
+@NavidZ 
+@domenic
+@patrickhlauke


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 27, 2020, 1:31 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fliviutinta%2Fpointerevents%2Fec324ae79c708178c8c361dea73f0244197e2a82%2Findex.html%3FisPreview%3Dtrue)

```
[33m📡 HTTP Error 522:[39m [36mhttps://rawcdn.githack.com/liviutinta/pointerevents/ec324ae79c708178c8c361dea73f0244197e2a82/index.html[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/pointerevents%23322.)._
</details>
