### PR TITLE
Update azimuth/altitude/tiltX/tiltY to not require default values in pointer events web idl

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,14 +424,21 @@ interface PointerEvent : MouseEvent {
                 <p>The <dfn><code>PointerEventInit</code></dfn> dictionary is used by the <dfn><code>PointerEvent</code></dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UI-EVENTS]]. The steps for constructing an event are defined in [[DOM]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
 
                 <div class="note">
-                    Pointer Events include two complementary sets of attributes to express the orientation of a transducer relative to the X-Y plane: <dfn><code>tiltX</code></dfn> / <dfn><code>tiltY</code></dfn> (introduced in the original Pointer Events specification), and <dfn><code>altitudeAngle</code></dfn> / <dfn><code>azimuthAngle</code></dfn> (adopted from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).
-                    Implementations MUST support both sets of attributes. When an untrusted (synthetic) Pointer Event is created programmatically using the constructor, and only one set of attributes is provided, the complementary set of attributes MUST be calculated and initialized by the user agent. If both sets of attributes are provided, no calculation should be performed.
-
-                    <p>
-                    If <code>azimuth</code> and <code>altitude</code> are provided, the user agent MUST initialize <code>tiltX</code>, <code>tiltY</code>
-                    with the calculated values rounded to the nearest integer value. For values falling exactly midway between integers, the user agend MUST always round up.
-                    </p>
-                    <p>If only the value of one of the two attributes is provided, the other attribute MUST be initialized to the default value.</p>
+                    <p>Pointer Events include two complementary sets of attributes to express the orientation of a
+                    transducer relative to the X-Y plane: <code>tiltX</code> / <code>tiltY</code>
+                    (introduced in the original Pointer Events specification), and
+                    <code>azimuthAngle</code> / <code>altitudeAngle</code>
+                    (adopted from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).
+                    Implementations SHOULD provide both sets of attributes for trusted events.</p>
+                    <p>When an untrusted (synthetic) Pointer Event is created programmatically using the constructor,
+                    and only one set of attributes is provided, the complementary set of attributes SHOULD be calculated and
+                    initialized by the user agent. If both sets of attributes are provided, no calculation should be performed.
+                    If only the value of one of the two attributes is provided, the other attribute SHOULD be initialized to
+                    the default value.</p>
+                    <p>When the user agent calculates <code>tiltX</code> / <code>tiltY</code> from
+                    <code>azimuthAngle</code> / <code>altitudeAngle</code> it SHOULD round the final integer values using
+                    <a href="https://tc39.es/ecma262/#sec-math.round"><code>Math.round</code></a> ([[ECMA-262]]) rules.</p>
+                    <p></p>
                 </div>
 
                 <p>A <a>PointerEvent</a> has an associated <dfn>coalesced event list</dfn> (a list of
@@ -685,7 +692,7 @@ interface PointerEvent : MouseEvent {
                     <ol>
                         <li>If the <a>pointer capture target override</a> for this pointer is set and is not equal to the <a>pending pointer capture target override</a>, then fire a pointer event named <code>lostpointercapture</code> at the <a>pointer capture target override</a> node.
                         </li>
-                        <li>If the <a>pending pointer capture target override</a> for this pointer is set and is not equal to the <a>pointer capture target override</a>, then fire a pointer event named <code>gotpointercapture</code> at the <a>pending pointer capture target override</a>. 
+                        <li>If the <a>pending pointer capture target override</a> for this pointer is set and is not equal to the <a>pointer capture target override</a>, then fire a pointer event named <code>gotpointercapture</code> at the <a>pending pointer capture target override</a>.
                         </li>
                         <li>Set the <dfn>pointer capture target override</dfn> to the <a>pending pointer capture target override</a>, if set. Otherwise, clear the <a>pointer capture target override</a>.</li>
                     </ol>

--- a/index.html
+++ b/index.html
@@ -284,11 +284,11 @@ dictionary PointerEventInit : MouseEventInit {
     double      height = 1;
     float       pressure = 0;
     float       tangentialPressure = 0;
-    long        tiltX = 0;
-    long        tiltY = 0;
+    long        tiltX;
+    long        tiltY;
     long        twist = 0;
-    double      altitudeAngle = 0;
-    double      azimuthAngle = 0;
+    double      altitudeAngle;
+    double      azimuthAngle;
     DOMString   pointerType = "";
     boolean     isPrimary = false;
     sequence&lt;PointerEvent> coalescedEvents = [];
@@ -361,7 +361,13 @@ interface PointerEvent : MouseEvent {
                         </dd>
                     <dt><dfn>altitudeAngle</dfn></dt>
                         <dd>
-                            <p>The altitude (in radians) of the transducer (e.g. pen stylus), in the range [0,π/2] - where 0 is parallel to the surface (X-Y plane), and π/2 is perpendicular to the surface. For hardware and platforms that do not report tilt or angle, the value MUST be 0.</p>
+                            <p>The altitude (in radians) of the transducer (e.g. pen stylus), in the range [0,π/2] - where 0 is parallel to the surface (X-Y plane), and π/2 is perpendicular to the surface. For hardware and platforms that do not report tilt or angle, the value MUST be π/2.</p>
+                            <div class="note">
+                                When the hardware or platform does not report the tilt or angle, as opposed to the default value of 0 defined for <code>altitudeAngle</code>
+                                in <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification,
+                                the default value defined here is π/2. This correlates with the default values of 0 for both <code>tiltX</code> and
+                                <code>tiltY</code> (when the hardware or platform do not report them) which positions the transducer as being perpendicular to the surface.
+                            </div>
                         </dd>
                     <dt><dfn>azimuthAngle</dfn></dt>
                         <dd>
@@ -417,8 +423,16 @@ interface PointerEvent : MouseEvent {
 
                 <p>The <dfn><code>PointerEventInit</code></dfn> dictionary is used by the <dfn><code>PointerEvent</code></dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UI-EVENTS]]. The steps for constructing an event are defined in [[DOM]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
 
-                <div class-"note">Pointer Events include two complementary sets of attributes to express the orientation of a transducer relative the X-Z plane: <dfn><code>tiltX</code></dfn> / <dfn><code>tiltY</code></dfn> (introduced in the original Pointer Events specification), and <dfn><code>altitudeAngle</code></dfn> / <dfn><code>azimuthAngle</code></dfn> (adopted from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).
-                    Implementations MUST support both sets of attributes. When an untrusted (synthetic) Pointer Event is created programmatically using the constructor, and only one set of values is provided, the complementary set of attributes MUST be calculated and initialized.</div>
+                <div class="note">
+                    Pointer Events include two complementary sets of attributes to express the orientation of a transducer relative to the X-Y plane: <dfn><code>tiltX</code></dfn> / <dfn><code>tiltY</code></dfn> (introduced in the original Pointer Events specification), and <dfn><code>altitudeAngle</code></dfn> / <dfn><code>azimuthAngle</code></dfn> (adopted from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).
+                    Implementations MUST support both sets of attributes. When an untrusted (synthetic) Pointer Event is created programmatically using the constructor, and only one set of attributes is provided, the complementary set of attributes MUST be calculated and initialized by the user agent. If both sets of attributes are provided, no calculation should be performed.
+
+                    <p>
+                    If <code>azimuth</code> and <code>altitude</code> are provided, the user agent MUST initialize <code>tiltX</code>, <code>tiltY</code>
+                    with the calculated values rounded to the nearest integer value. For values falling exactly midway between integers, the user agend MUST always round up.
+                    </p>
+                    <p>If only the value of one of the two attributes is provided, the other attribute MUST be initialized to the default value.</p>
+                </div>
 
                 <p>A <a>PointerEvent</a> has an associated <dfn>coalesced event list</dfn> (a list of
                 zero or more <code>PointerEvents</code>). If this event is a <code>pointermove</code>


### PR DESCRIPTION
Remove default values for `tiltX`,`tiltY`,`azimuthAngle`,`altitudeAngle`.
Change default value for `altitudeAngle` to `π/2`.
Describe rounding method for calculated `tiltX`,`tiltY`.
If only the value for one attribute is specified, the other attribute must be populated with the default value.
+@patrickhlauke 
+@smaug----  
+@NavidZ
+@domenic


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/liviutinta/pointerevents/pull/323.html" title="Last updated on Jun 26, 2020, 8:58 PM UTC (8e22d72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/323/0dd4377...liviutinta:8e22d72.html" title="Last updated on Jun 26, 2020, 8:58 PM UTC (8e22d72)">Diff</a>