### PR TITLE
gotpointercapture/lostpointercapture might never fire

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,6 +694,11 @@ interface PointerEvent : MouseEvent {
                         </li>
                         <li>Set the <dfn>pointer capture target override</dfn> to the <a>pending pointer capture target override</a>, if set. Otherwise, clear the <a>pointer capture target override</a>.</li>
                     </ol>
+                    <div class="note">Firing <code>gotpointercapture</code>, <code>lostpointercapture</code> is
+                        delayed until the next pointer event. If there are no pointer events after calls to
+                        <code>element.setPointerCapture(pointerId)</code> or
+                        <code>element.releasePointerCapture(pointerId)</code>, the events
+                        <code>gotpointercapture</code>, <code>lostpointercapture</code> will never fire.</div>
                 </section>
             </section>
         </section>


### PR DESCRIPTION
While working on wpt tests I found a case where the lostpointercapture event
was never firing because there was no other synthetic pointer event after
calling releasePointerCapture for that frame.
Looking into that I found about [pointerevents issue 32](https://github.com/w3c/pointerevents/issues/32) where it was decided gotpointercapture
and lostpointercapture will be delayed until the next pointer event.
This wasn't clear to me when I read the spec, so I thought I'll propose a
note to specifically call this out.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/liviutinta/pointerevents/pull/354.html" title="Last updated on Mar 10, 2021, 9:02 PM UTC (066d791)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/354/46346e9...liviutinta:066d791.html" title="Last updated on Mar 10, 2021, 9:02 PM UTC (066d791)">Diff</a>