### PR TITLE
Move glossary to the end of the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,38 +238,6 @@ eventTarget.dispatchEvent(event2);</code>
 </pre>
     </section>
 
-    <section class="informative">
-        <h1>Glossary</h1>
-        <dl>
-            <dt><dfn>active buttons state</dfn></dt>
-                <dd>The condition when a pointer has a non-zero value for the <code>buttons</code> property. For mouse, this is when the device has at least one button depressed. For touch, this is when there is physical contact with the digitizer. For pen, this is when either the pen has physical contact with the digitizer, or at least one button is depressed while hovering.</dd>
-            <dt><dfn>active document</dfn></dt>
-                <dd>For every <a>active pointer</a>, the document that received the last event from that pointer.</dd>
-            <dt><dfn>active pointer</dfn></dt>
-                <dd>Any touch contact, pen stylus, mouse cursor, or other pointer that can produce events.  If it is possible for a given pointer (identified by a unique <code>pointerId</code>) to produce additional events within the document, then that pointer is still considered active. Examples:
-                    <ul>
-                        <li>A mouse connected to the device is always active.</li>
-                        <li>A touch contact on the screen is considered active.</li>
-                        <li>If a touch contact or pen stylus is lifted beyond the range of the digitizer, then it is no longer considered active.</li>
-                    </ul>
-                    <div class="note">On some platforms, the set of active pointers includes all pointer input to the device, including any that are not targeted at the user agent (e.g. those targeted at other applications).</div>
-                    <div class="note">Each active pointer should have the same id within the scope of the <a>top-level browsing context</a> (as defined by [[HTML]]). However, there is no such guarantee across multiple <a>top-level browsing contexts</a>. </div>
-                </dd>
-            <dt><dfn>canceled event</dfn></dt>
-                <dd>An event whose default action was prevented by means of <code>preventDefault()</code>, returning <code>false</code> in an event handler, or other means as defined by [[UIEVENTS]] and [[HTML]].</dd>
-            <dt><dfn>contact geometry</dfn></dt>
-                <dd>The bounding box of an input (most commonly, touch) on a digitizer. This typically refers to devices with coarser pointer input resolution than a single pixel. Some devices do not report this data at all.</dd>
-            <dt><dfn>digitizer</dfn></dt>
-                <dd>A type of input sensing device in which a surface can detect input which is in contact and/or in close proximity. Most commonly, this is the surface that senses input from the touch contact or a pen stylus.</dd>
-            <dt><dfn>hit test</dfn></dt>
-                <dd>The process by which a user agent determines a target element for a pointer event. Typically, this is determined by considering the pointer's location and also the visual layout of elements in a document on screen media.</dd>
-            <dt><dfn>pointer</dfn></dt>
-                <dd>A hardware agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen, such as a mouse, pen, or touch contact.</dd>
-            <dt><dfn>user agent</dfn></dt>
-                <dd>A program, such as a browser or content authoring tool, normally running on a client machine, which acts on a user's behalf in retrieving, interpreting, executing, presenting, or creating content.</dd>
-        </dl>
-    </section>
-
     <section>
         <h1>Pointer Events and Interfaces</h1>
         <section>
@@ -1332,6 +1300,37 @@ function tilt2spherical(tiltX, tiltY){
   return {"altitudeAngle":altitudeAngle, "azimuthAngle":azimuthAngle};
 }</code>
 </pre>
+    </section>
+    <section class="informative">
+        <h1>Glossary</h1>
+        <dl>
+            <dt><dfn>active buttons state</dfn></dt>
+                <dd>The condition when a pointer has a non-zero value for the <code>buttons</code> property. For mouse, this is when the device has at least one button depressed. For touch, this is when there is physical contact with the digitizer. For pen, this is when either the pen has physical contact with the digitizer, or at least one button is depressed while hovering.</dd>
+            <dt><dfn>active document</dfn></dt>
+                <dd>For every <a>active pointer</a>, the document that received the last event from that pointer.</dd>
+            <dt><dfn>active pointer</dfn></dt>
+                <dd>Any touch contact, pen stylus, mouse cursor, or other pointer that can produce events.  If it is possible for a given pointer (identified by a unique <code>pointerId</code>) to produce additional events within the document, then that pointer is still considered active. Examples:
+                    <ul>
+                        <li>A mouse connected to the device is always active.</li>
+                        <li>A touch contact on the screen is considered active.</li>
+                        <li>If a touch contact or pen stylus is lifted beyond the range of the digitizer, then it is no longer considered active.</li>
+                    </ul>
+                    <div class="note">On some platforms, the set of active pointers includes all pointer input to the device, including any that are not targeted at the user agent (e.g. those targeted at other applications).</div>
+                    <div class="note">Each active pointer should have the same id within the scope of the <a>top-level browsing context</a> (as defined by [[HTML]]). However, there is no such guarantee across multiple <a>top-level browsing contexts</a>. </div>
+                </dd>
+            <dt><dfn>canceled event</dfn></dt>
+                <dd>An event whose default action was prevented by means of <code>preventDefault()</code>, returning <code>false</code> in an event handler, or other means as defined by [[UIEVENTS]] and [[HTML]].</dd>
+            <dt><dfn>contact geometry</dfn></dt>
+                <dd>The bounding box of an input (most commonly, touch) on a digitizer. This typically refers to devices with coarser pointer input resolution than a single pixel. Some devices do not report this data at all.</dd>
+            <dt><dfn>digitizer</dfn></dt>
+                <dd>A type of input sensing device in which a surface can detect input which is in contact and/or in close proximity. Most commonly, this is the surface that senses input from the touch contact or a pen stylus.</dd>
+            <dt><dfn>hit test</dfn></dt>
+                <dd>The process by which a user agent determines a target element for a pointer event. Typically, this is determined by considering the pointer's location and also the visual layout of elements in a document on screen media.</dd>
+            <dt><dfn>pointer</dfn></dt>
+                <dd>A hardware agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen, such as a mouse, pen, or touch contact.</dd>
+            <dt><dfn>user agent</dfn></dt>
+                <dd>A program, such as a browser or content authoring tool, normally running on a client machine, which acts on a user's behalf in retrieving, interpreting, executing, presenting, or creating content.</dd>
+        </dl>
     </section>
     <section>
         <h2>Security and privacy considerations</h2>

--- a/index.html
+++ b/index.html
@@ -1301,6 +1301,31 @@ function tilt2spherical(tiltX, tiltY){
 }</code>
 </pre>
     </section>
+    <section>
+        <h2>Security and privacy considerations</h2>
+        <p>This appendix discusses security and privacy considerations for Pointer Events implementations. The discussion is limited to security and privacy issues that arise directly from implementation of the event model, APIs and events defined in this specification.</p>
+        <p>Many of the event types defined in this specification are dispatched in response to user actions. This allows malicious event listeners to gain access to information users would typically consider confidential, e.g., the exact path/movement of a user's mouse/stylus/finger while interacting with a page.</p>
+        <p>Pointer events contain additional information (where supported by the user's device), such as the angle or tilt at which a pen input is held, the geometry of the contact surface, and the pressure exerted on the stylus or touch screen. Information about angle, tilt, geometry and pressure are directly related to sensors on the user's device, meaning that this specification allows an origin access to these sensors.</p>
+        <p>This sensor data, as well as the ability to determine the type of input mechanism (mouse, touch, pen) used, may be used to infer characteristics of a user, or of the user's device and environment. These inferred characteristics and any device/environment information may themselves be sensitive - for instance, they may allow a malicious site to further infer if a user is using assistive technologies. This information can also be potentially used for the purposes of building a user profile and/or attempting to "fingerprint" and track a particular user.</p>
+        <p>As mitigation, user agents may consider including the ability for users to disable access to particular sensor data (such as angle, tilt, pressure), and/or to make it available only after an explicit opt-in from the user.</p>
+        <p>Beyond these considerations, the working group believes that this specification:</p>
+        <ul>
+            <li>Does not expose personally-identifiable information.</li>
+            <li>Does not deal with high-value data.</li>
+            <li>Does not introduce new state for an origin that persists across browsing sessions.</li>
+            <li>Does not expose persistent, cross-origin state to the web.</li>
+            <li>Does not expose any other data to an origin that it doesn’t currently have access to.</li>
+            <li>Does not enable new script execution/loading mechanisms.</li>
+            <li>Does not allow an origin access to a user’s location.</li>
+            <li>Does not require any special handling when the user agent is in "incognito" mode.</li>
+            <li>Does not allow an origin access to other devices.</li>
+            <li>Does not allow an origin control over a user agent’s native UI.</li>
+            <li>Does not expose temporary identifiers to the web.</li>
+            <li>Does not distinguish between behavior in first-party and third-party contexts.</li>
+            <li>Does not persist data to a user’s local device.</li>
+            <li>Does not allow downgrading default security characteristics.</li>
+        </ul>
+    </section>
     <section class="informative">
         <h1>Glossary</h1>
         <dl>
@@ -1331,31 +1356,6 @@ function tilt2spherical(tiltX, tiltY){
             <dt><dfn>user agent</dfn></dt>
                 <dd>A program, such as a browser or content authoring tool, normally running on a client machine, which acts on a user's behalf in retrieving, interpreting, executing, presenting, or creating content.</dd>
         </dl>
-    </section>
-    <section>
-        <h2>Security and privacy considerations</h2>
-        <p>This appendix discusses security and privacy considerations for Pointer Events implementations. The discussion is limited to security and privacy issues that arise directly from implementation of the event model, APIs and events defined in this specification.</p>
-        <p>Many of the event types defined in this specification are dispatched in response to user actions. This allows malicious event listeners to gain access to information users would typically consider confidential, e.g., the exact path/movement of a user's mouse/stylus/finger while interacting with a page.</p>
-        <p>Pointer events contain additional information (where supported by the user's device), such as the angle or tilt at which a pen input is held, the geometry of the contact surface, and the pressure exerted on the stylus or touch screen. Information about angle, tilt, geometry and pressure are directly related to sensors on the user's device, meaning that this specification allows an origin access to these sensors.</p>
-        <p>This sensor data, as well as the ability to determine the type of input mechanism (mouse, touch, pen) used, may be used to infer characteristics of a user, or of the user's device and environment. These inferred characteristics and any device/environment information may themselves be sensitive - for instance, they may allow a malicious site to further infer if a user is using assistive technologies. This information can also be potentially used for the purposes of building a user profile and/or attempting to "fingerprint" and track a particular user.</p>
-        <p>As mitigation, user agents may consider including the ability for users to disable access to particular sensor data (such as angle, tilt, pressure), and/or to make it available only after an explicit opt-in from the user.</p>
-        <p>Beyond these considerations, the working group believes that this specification:</p>
-        <ul>
-            <li>Does not expose personally-identifiable information.</li>
-            <li>Does not deal with high-value data.</li>
-            <li>Does not introduce new state for an origin that persists across browsing sessions.</li>
-            <li>Does not expose persistent, cross-origin state to the web.</li>
-            <li>Does not expose any other data to an origin that it doesn’t currently have access to.</li>
-            <li>Does not enable new script execution/loading mechanisms.</li>
-            <li>Does not allow an origin access to a user’s location.</li>
-            <li>Does not require any special handling when the user agent is in "incognito" mode.</li>
-            <li>Does not allow an origin access to other devices.</li>
-            <li>Does not allow an origin control over a user agent’s native UI.</li>
-            <li>Does not expose temporary identifiers to the web.</li>
-            <li>Does not distinguish between behavior in first-party and third-party contexts.</li>
-            <li>Does not persist data to a user’s local device.</li>
-            <li>Does not allow downgrading default security characteristics.</li>
-        </ul>
     </section>
     <section class="appendix">
         <h1>Acknowledgments</h1>


### PR DESCRIPTION
Closes https://github.com/w3c/pointerevents/issues/362


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/363.html" title="Last updated on Apr 21, 2021, 10:35 AM UTC (6bb3817)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/363/5565d23...6bb3817.html" title="Last updated on Apr 21, 2021, 10:35 AM UTC (6bb3817)">Diff</a>