### PR TITLE
Expand the definition/explanation of predicted events timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -1066,10 +1066,17 @@ partial interface Navigator {
             <p>The number of events in the list and how far they are from the current timestamp are determined by
             the user agent and the prediction algorithm it uses.</p>
                 
-            <p>The events in the predicted event list will have increasing
+            <p>The events in the predicted event list will have monotonically increasing
             <a href="https://dom.spec.whatwg.org/#dom-event-timestamp"><code>timeStamps</code></a>([[!WHATWG-DOM]]),
-            so the first event will have the smallest <code>timeStamp</code> which should still be greater than
-            the last event in the <a>coalesced event list</a>.</p>
+            so the first event will have the smallest <code>timeStamp</code>. All predicted events have a <code>timeStamp</code>
+            that is greater than the <code>timeStamp</code> of the dispatched pointer event that the
+            <code><a data-lt="PointerEvent.getPredictedEvents">getPredictedEvents</a></code> method was called on.</p>
+
+            <div class="note">
+                <p>Note that authors should only consider predicted events as valid predictions until the next pointer event is
+                dispatched. It is possible, depending on how far into the future the user agent predicts events, that regular
+                pointer events are dispatched earlier than the timestamp of one or more of the predicted events.</p>
+            </div>
 
             <pre id="example_11" class="example" title="Conceptual approach to drawing using coalesced events and predicted events">
                 <code>


### PR DESCRIPTION
- reword/expand on the timestamps for predicted events. rather than saying it should be greater than the last event in the coalesced list, it probably makes more sense to say it must be greater than the "real" pointer event where the method was called
- add the layman's terms note about "they're only valid predictions until reality sets in with the next dispatched event"

Closes https://github.com/w3c/pointerevents/issues/282


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/382.html" title="Last updated on Jun 2, 2021, 2:43 PM UTC (fc5dc2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/382/fde3610...fc5dc2d.html" title="Last updated on Jun 2, 2021, 2:43 PM UTC (fc5dc2d)">Diff</a>