### PR TITLE
Explicit note about pointerrawmove having an empty predicted event list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1063,6 +1063,10 @@ partial interface Navigator {
             <code>PointerEvent</code>s). If this event is a <code>pointermove</code> event, it is a sequence of
             <code>PointerEvent</code>s that the user agent predicts will follow the events in the
             <a>coalesced event list</a> in the future; otherwise it is an empty list.</p>
+            <div class="note">
+                <p>While <code>pointerrawmove</code> events may have a non-empty <a>coalesced event list</a>,
+                their <a>predicted event list</a> will, for performance reasons, always be an empty list.</p>
+            </div>
             <p>The number of events in the list and how far they are from the current timestamp are determined by
             the user agent and the prediction algorithm it uses.</p>
                 

--- a/index.html
+++ b/index.html
@@ -1065,7 +1065,7 @@ partial interface Navigator {
             <a>coalesced event list</a> in the future; otherwise it is an empty list.</p>
             <div class="note">
                 <p>While <code>pointerrawmove</code> events may have a non-empty <a>coalesced event list</a>,
-                their <a>predicted event list</a> will, for performance reasons, always be an empty list.</p>
+                their <a>predicted event list</a> will, for performance reasons, usually be an empty list.</p>
             </div>
             <p>The number of events in the list and how far they are from the current timestamp are determined by
             the user agent and the prediction algorithm it uses.</p>


### PR DESCRIPTION
Closes https://github.com/w3c/pointerevents/issues/380


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/383.html" title="Last updated on Jun 3, 2021, 7:46 PM UTC (d07225a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/383/fde3610...d07225a.html" title="Last updated on Jun 3, 2021, 7:46 PM UTC (d07225a)">Diff</a>