### PR TITLE
task queue is not reliable HTML concept. Use event loop instead

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,11 +558,11 @@ interface PointerEvent : MouseEvent {
                 due to the fact that <code>pointermove</code> events might get aligned with animation frame callbacks and get coalesced, and the final position of the event
                 which is used for finding the <code>target</code> could be different from its coalesced events.</p>
                 <p>Note that if there is already another <code>pointerrawupdate</code> with the same <code>pointerId</code> that hasn't been dispatched
-                in the <a data-cite="html/#task-queue">task queue</a>, the
+                in the [=event loop=], the
                 user agent MAY coalesce the new <code>pointerrawupdate</code> with that event instead of creating a new [=task=].
                 This may cause <code>pointerrawupdate</code> to have coalesced events, and
                 they will all be delivered as <a>coalesced events</a> of one <code>pointerrawupdate</code> event as soon as
-                the event is processed in the <a data-cite="html/#task-queue">task queue</a>.
+                the event is processed in the [=event loop=].
                 See <code><a data-lt="PointerEvent.getCoalescedEvents">getCoalescedEvents</a></code> for more information.</p>
                 <p>In terms of ordering of <code>pointerrawupdate</code> and <code>pointermove</code>,
                 if the user agent received an update from the platform that causes both <code>pointerrawupdate</code> and <code>pointermove</code> events,


### PR DESCRIPTION
From https://github.com/whatwg/html/issues/6758

"task queue" is a HTML-internal concept. Suggestion is to use event loop.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/386.html" title="Last updated on Jun 10, 2021, 6:05 PM UTC (232d422)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/386/6b7e5e7...232d422.html" title="Last updated on Jun 10, 2021, 6:05 PM UTC (232d422)">Diff</a>