### PR TITLE
Tweak the definition of coalesced event list to deal with untrusted e…

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,11 +963,13 @@ partial interface Navigator {
             </figure>
 
             <p>A <a>PointerEvent</a> has an associated <dfn>coalesced event list</dfn> (a list of
-            zero or more <code>PointerEvent</code>s). If this event is a <code>pointermove</code>
-            or <code>pointerrawupdate</code> event, the list is a sequence of all <code>PointerEvent</code>s
-            that were coalesced into this event; otherwise it is an empty list.</p>
+            zero or more <code>PointerEvent</code>s). If a trusted event is a <code>pointermove</code> or
+            <code>pointerrawupdate</code> event, the list is a sequence of all <code>PointerEvent</code>s
+            that were coalesced into this event; otherwise it is an empty list.
+            Untrusted events have their <a>coalesced event list</a> initialized to the value passed to the
+            constructor.</p>
 
-            <p>The events in the coalesced event list will have increasing
+            <p>The events in the coalesced event list of a trusted event will have increasing
             {{Event/timeStamp}}s, so the first event will have the smallest {{Event/timeStamp}}.</p>
 
             <pre id="example_10" class="example" title="Basic canvas drawing application using the coalesced events list">


### PR DESCRIPTION
…vents, see https://github.com/w3c/pointerevents/issues/224


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 7, 2021, 12:00 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fsmaug----%2Fpointerevents%2Fea15c0094d13f86491df26914a7e20d45a880bc0%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 29249 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/pointerevents%23391.)._
</details>
