### PR TITLE
Remove note about movementX/movementY and coalesced events

### DIFF
--- a/index.html
+++ b/index.html
@@ -1008,8 +1008,8 @@ partial interface Navigator {
             </pre>
 
             <div class="note">The PointerEvent's attributes will be initalized in a way that best represents
-            the events in the coalesced events list. For example its {{MouseEvent/movementX}} and {{MouseEvent/movementY}}
-            ([[PointerLock]]) COULD be the sum of those of all the coalesced events.</div>
+            the events in the coalesced events list. The specific method by which user agents should do this is not covered by
+            this specification.</div>
 
             <div class="note">
                 <p>The order of all these dispatched events should resemble the actual order of the


### PR DESCRIPTION
As our spec clearly says it's not trying to define HOW coalescing is done by UAs, this note (particularly as it relates to some other properties not of this spec) feels odd. If anything, this is the sort of detail that could/should be defined in the PointerLock spec?

Closes https://github.com/w3c/pointerevents/issues/374


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/397.html" title="Last updated on Jul 21, 2021, 3:43 PM UTC (1fc5211)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/397/a7ce1ff...1fc5211.html" title="Last updated on Jul 21, 2021, 3:43 PM UTC (1fc5211)">Diff</a>