### PR TITLE
Clarify `pointercancel` firing behavior on drag.

### DIFF
--- a/index.html
+++ b/index.html
@@ -591,7 +591,7 @@ interface PointerEvent : MouseEvent {
                      <div class="note">User agents can trigger panning or zooming through multiple pointer types (such as touch and pen),
                      and therefore the start of a pan or zoom action may result in the cancellation of various pointers, including pointers with different pointer types.
                      To prevent cancellation of the pointer stream due to these behaviors see <a href="#the-touch-action-css-property">the touch-action CSS property section</a>.</div></li>
-                    <li>As part of the drag operation initiaion algorithm as defined in the <a data-cite="html/#drag-and-drop-processing-model">drag and drop processing model</a> [[HTML]],
+                    <li>As part of the drag operation initiation algorithm as defined in the <a data-cite="html/#drag-and-drop-processing-model">drag and drop processing model</a> [[HTML]],
                      for the pointer that caused the drag operation.</li>
                 </ul>
                 <p>After firing the <code>pointercancel</code> event, a user agent MUST also fire a pointer event named <code>pointerout</code> followed by firing a pointer event named <code>pointerleave</code>, and <a href="#implicit-release-of-pointer-capture">implicitly release the pointer capture</a> if the pointer is currently captured.</p>

--- a/index.html
+++ b/index.html
@@ -579,6 +579,7 @@ interface PointerEvent : MouseEvent {
                 <h3>The <dfn><code>pointerup</code> event</dfn></h3>
                 <p>A user agent MUST <a>fire a pointer event</a> named <code>pointerup</code> when a pointer leaves the <a>active buttons state</a>. For mouse, this is when the device transitions from at least one button depressed to no buttons depressed. For touch, this is when physical contact is removed from the <a>digitizer</a>. For pen, this is when the pen is removed from the physical contact with the digitizer while no button is depressed, or transitions from at least one button depressed to no buttons depressed while hovering.</p>
                 <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, a user agent MUST also <a>fire a pointer event</a> named <code>pointerout</code> followed by a pointer event named <code>pointerleave</code> after dispatching the <code>pointerup</code> event.</p>
+                <p>The user agent MUST also <a href="#implicit-release-of-pointer-capture">implicitly release the pointer capture</a> if the pointer is currently captured.</p>
                 <div class="note">For mouse (or other multi-button pointer devices), this means <code>pointerdown</code> and <code>pointerup</code> are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a href="#chorded-button-interactions">chorded buttons</a> for more information.</div>
             </section>
             <section>
@@ -590,13 +591,10 @@ interface PointerEvent : MouseEvent {
                      <div class="note">User agents can trigger panning or zooming through multiple pointer types (such as touch and pen),
                      and therefore the start of a pan or zoom action may result in the cancellation of various pointers, including pointers with different pointer types.
                      To prevent cancellation of the pointer stream due to these behaviors see <a href="#the-touch-action-css-property">the touch-action CSS property section</a>.</div></li>
-                    <li>Immediately before <a data-cite="html/#initiate-the-drag-and-drop-operation">drag operation starts</a> [[HTML]],
-                     for the pointer that caused the drag operation.
-                     <div class="note">If the start of the drag operation is prevented through any means
-                     (e.g. through calling <code>preventDefault</code> on the <code>dragstart</code> event)
-                     there will be no <code>pointercancel</code> event.</div></li>
+                    <li>As part of the drag operation initiaion algorithm as defined in the <a data-cite="html/#drag-and-drop-processing-model">drag and drop processing model</a> [[HTML]],
+                     for the pointer that caused the drag operation.</li>
                 </ul>
-                <p>After firing the <code>pointercancel</code> event, a user agent MUST also fire a pointer event named <code>pointerout</code> followed by firing a pointer event named <code>pointerleave</code>.</p>
+                <p>After firing the <code>pointercancel</code> event, a user agent MUST also fire a pointer event named <code>pointerout</code> followed by firing a pointer event named <code>pointerleave</code>, and <a href="#implicit-release-of-pointer-capture">implicitly release the pointer capture</a> if the pointer is currently captured.</p>
                 <div class="note">
                     <p><em>This section is non-normative.</em></p>
                     <p>Examples of scenarios in which a user agent might determine that a pointer is unlikely to continue to produce events include:


### PR DESCRIPTION
This PR will follow the addition of `pointercancel` event firing step
in the HTML spec: https://github.com/whatwg/html/pull/6912.

Closes #384
Addresses one problem in https://github.com/whatwg/html/issues/6758

Also adds a missing link for implicit release of pointer capture for `pointerup`
and `pointercancel` events.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mustaqahmed/pointerevents/pull/398.html" title="Last updated on Aug 3, 2021, 2:12 PM UTC (5beb527)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/398/36924db...mustaqahmed:5beb527.html" title="Last updated on Aug 3, 2021, 2:12 PM UTC (5beb527)">Diff</a>