### PR TITLE
Move definition point for PointerEvent

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,7 +322,7 @@ interface PointerEvent : MouseEvent {
                         </dd>
                 </dl>
 
-                <p>The <dfn>PointerEventInit</dfn> dictionary is used by the <dfn>PointerEvent</dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. The [=event constructing steps=] are defined in the [[[DOM]]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
+                <p>The <dfn>PointerEventInit</dfn> dictionary is used by the {{PointerEvent}} interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. The [=event constructing steps=] are defined in the [[[DOM]]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
 
                 <div class="note">
                     <p>Pointer Events include two complementary sets of attributes to express the orientation of a


### PR DESCRIPTION
Currently, references to `{{PointerEvent}}` / `<a>PointerEvent</a>` link to/land on the sentence "The PointerEventInit dictionary is used by the PointerEvent interface's constructor..." which comes *after* the WebIDL and explanation prose for all the properties/methods. https://w3c.github.io/pointerevents/#dom-pointerevent
With this change, the `<dfn>` there is removed, and as a result, references to PointerEvent now link to (thanks to Respec) the actual WebIDL definition itself, which seems far more logical. This is in line (by the look of it) with how other specs handle this (see for instance https://www.w3.org/TR/uievents/#mouseevent which links to the WebIDL)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/406.html" title="Last updated on Aug 5, 2021, 12:46 PM UTC (c0e2829)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/406/6d33e08...c0e2829.html" title="Last updated on Aug 5, 2021, 12:46 PM UTC (c0e2829)">Diff</a>