### PR TITLE
Make "Converting..." section normative

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,23 +324,6 @@ interface PointerEvent : MouseEvent {
 
                 <p>The <dfn>PointerEventInit</dfn> dictionary is used by the {{PointerEvent}} interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. The [=event constructing steps=] are defined in the [[[DOM]]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
 
-                <div class="note">
-                    <p>Pointer Events include two complementary sets of attributes to express the orientation of a
-                    transducer relative to the X-Y plane: <code>tiltX</code> / <code>tiltY</code>
-                    (introduced in the original Pointer Events specification), and
-                    <code>azimuthAngle</code> / <code>altitudeAngle</code>
-                    (adopted from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).
-                    Implementations SHOULD provide both sets of attributes for trusted events.</p>
-                    <p>When an untrusted (synthetic) Pointer Event is created programmatically using the constructor,
-                    and only one set of attributes is provided, the complementary set of attributes SHOULD be calculated and
-                    initialized by the user agent. If both sets of attributes are provided, no calculation should be performed.
-                    If only the value of one of the two attributes is provided, the other attribute SHOULD be initialized to
-                    the default value.</p>
-                    <p>When the user agent calculates <code>tiltX</code> / <code>tiltY</code> from
-                    <code>azimuthAngle</code> / <code>altitudeAngle</code> it SHOULD round the final integer values using
-                    <a data-cite="ECMASCRIPT#sec-math.round">Math.round</a> [[ECMASCRIPT]] rules.</p>
-                </div>
-
                 <div class="note">The <code>PointerEvent</code> interface inherits from {{MouseEvent}}, defined in [[[UIEVENTS]]].
                     Also note the proposed extension in [[[CSSOM-VIEW]]], which changes the various coordinate properties from <code>long</code>
                     to <code>double</code> to allow for fractional coordinates. For user agents that already implement this proposed extension for
@@ -1268,9 +1251,15 @@ partial interface Navigator {
             </div>
         </section>
     </section>
-    <section class='informative'>
+    <section>
         <h2>Converting between <code>tiltX</code> / <code>tiltY</code> and <code>altitudeAngle</code> / <code>azimuthAngle</code></h2>
-        <p>Depending on the specific hardware and platform, user agents will likely only receive one set of values for the transducer orientation relative to the screen plane — either <code>tiltX</code> / <code>tiltY</code> or <code>altitudeAngle</code> / <code>azimuthAngle</code>. The following basic code provides an initial suggested approach for converting these values.</p>
+        <p>Pointer Events include two complementary sets of attributes to express the orientation of a transducer relative to the X-Y plane:
+            <code>tiltX</code> / <code>tiltY</code> (introduced in the original Pointer Events specification), and
+            <code>azimuthAngle</code> / <code>altitudeAngle</code>
+            (adopted from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification).</p>
+        <p>Depending on the specific hardware and platform, user agents will likely only receive one set of values for the transducer orientation relative to the screen plane — either <code>tiltX</code> / <code>tiltY</code> or <code>altitudeAngle</code> / <code>azimuthAngle</code>. User agents MUST use the following algorithm for converting these values.</p>
+        <p>When the user agent calculates <code>tiltX</code> / <code>tiltY</code> from <code>azimuthAngle</code> / <code>altitudeAngle</code> it SHOULD
+            round the final integer values using <a data-cite="ECMASCRIPT#sec-math.round">Math.round</a> [[ECMASCRIPT]] rules.</p>
         <pre id="example_12" class="example" title="Converting between tiltX/tiltY and altitudeAngle/azimuthAngle"><code>/* Converting between tiltX/tiltY and altitudeAngle/azimuthAngle */
 
 function spherical2tilt(altitudeAngle, azimuthAngle){


### PR DESCRIPTION
- remove first note of https://w3c.github.io/pointerevents/#dom-pointerevent-getpredictedevents
- salvage useful parts and move them to "Converting..." section https://w3c.github.io/pointerevents/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle
- make "Converting..." normative, after tweaking sentence to clarify that UAs MUST use the algorithm https://w3c.github.io/pointerevents/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle

However, note that with this approach, while we have the `Math.round` SHOULD, the algorithm doesn't actually use it. Does the algorithm need changing?

x-ref https://github.com/w3c/pointerevents/issues/405 https://www.w3.org/2021/09/01-pointerevents-minutes.html#t02


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/410.html" title="Last updated on Sep 13, 2021, 5:42 PM UTC (fb46e32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/410/76c9195...fb46e32.html" title="Last updated on Sep 13, 2021, 5:42 PM UTC (fb46e32)">Diff</a>