### PR TITLE
Move first part of the note about dispatched event order into normative text

### DIFF
--- a/index.html
+++ b/index.html
@@ -1030,12 +1030,12 @@ partial interface Navigator {
             the events in the coalesced events list. The specific method by which user agents should do this is not covered by
             this specification.</div>
 
+            <p>The order of all these dispatched events should resemble the actual order of the
+            original events' order. For example if a <code>pointerdown</code> event causes the dispatch for the
+            coalesced <code>pointermove</code> events the user agent SHOULD first dispatch one <code>pointermove</code>
+            event with all those coalesced events of a <code>pointerId</code> followed by the <code>pointerdown</code> event.</p>
             <div class="note">
-                <p>The order of all these dispatched events should resemble the actual order of the
-                original events' order. For example if a <code>pointerdown</code> event causes the dispatch for the
-                coalesced <code>pointermove</code> events the user agent SHOULD first dispatch one <code>pointermove</code>
-                event with all those coalesced events of a <code>pointerId</code> followed by the <code>pointerdown</code> event.
-                Here is an example of the actual events happening with increasing {{Event/timeStamp}} values and the
+                <p>Here is an example of the actual events happening with increasing {{Event/timeStamp}} values and the
                 events dispatched by the user agent:</p>
                 <table class="simple">
                     <thead><tr><th>Actual events</th><th>Dispatched events</th> </tr></thead>

--- a/index.html
+++ b/index.html
@@ -1030,9 +1030,9 @@ partial interface Navigator {
             the events in the coalesced events list. The specific method by which user agents should do this is not covered by
             this specification.</div>
 
-            <p>The order of all these dispatched events should resemble the actual order of the
+            <p>The order of all these dispatched events MUST match the actual order of the
             original events' order. For example if a <code>pointerdown</code> event causes the dispatch for the
-            coalesced <code>pointermove</code> events the user agent SHOULD first dispatch one <code>pointermove</code>
+            coalesced <code>pointermove</code> events the user agent MUST first dispatch one <code>pointermove</code>
             event with all those coalesced events of a <code>pointerId</code> followed by the <code>pointerdown</code> event.</p>
             <div class="note">
                 <p>Here is an example of the actual events happening with increasing {{Event/timeStamp}} values and the


### PR DESCRIPTION
x-ref https://github.com/w3c/pointerevents/issues/405


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/412.html" title="Last updated on Sep 30, 2021, 11:10 PM UTC (d85a3c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/412/76c9195...d85a3c7.html" title="Last updated on Sep 30, 2021, 11:10 PM UTC (d85a3c7)">Diff</a>