### PR TITLE
Make note about UAs not firing compat events if they support touch events normative

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,9 +1227,7 @@ partial interface Navigator {
                 </li>
                 <li>If the pointer event dispatched was <code>pointerup</code> or <code>pointercancel</code>, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
             </ol>
-            <div class="note">
-                <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the user agent SHOULD NOT generate compatibility mouse events as described in this section as it is likely to introduce compatibility problems for sites that expect mouse events to be generated in accordance with the <a data-cite="touch-events/#mouse-events">model</a> outlined in [[TOUCH-EVENTS]].</p>
-            </div>
+            <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the user agent SHOULD NOT generate compatibility mouse events as described in this section as it is likely to introduce compatibility problems for sites that expect mouse events to be generated in accordance with the <a data-cite="touch-events/#mouse-events">model</a> outlined in [[TOUCH-EVENTS]].</p>
             <div class="note">
                 <p>The activation of an element (<code>click</code>) with a primary pointer that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (e.g. single finger on a touchscreen) would typically produce the following event sequence:</p>
                 <ol data-class="note-list">

--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@ partial interface Navigator {
                 </li>
                 <li>If the pointer event dispatched was <code>pointerup</code> or <code>pointercancel</code>, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
             </ol>
-            <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the user agent SHOULD NOT generate compatibility mouse events as described in this section as it is likely to introduce compatibility problems for sites that expect mouse events to be generated in accordance with the <a data-cite="touch-events/#mouse-events">model</a> outlined in [[TOUCH-EVENTS]].</p>
+            <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the user agent SHOULD NOT generate <em>both</em> the compatibility mouse events as described in this section, and the <a data-cite="touch-events/#mouse-events">fallback mouse events</a> outlined in [[TOUCH-EVENTS]], as a result of a touch or pen interaction.</p>
             <div class="note">
                 <p>The activation of an element (<code>click</code>) with a primary pointer that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (e.g. single finger on a touchscreen) would typically produce the following event sequence:</p>
                 <ol data-class="note-list">

--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@ partial interface Navigator {
                 </li>
                 <li>If the pointer event dispatched was <code>pointerup</code> or <code>pointercancel</code>, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
             </ol>
-            <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the user agent SHOULD NOT generate <em>both</em> the compatibility mouse events as described in this section, and the <a data-cite="touch-events/#mouse-events">fallback mouse events</a> outlined in [[TOUCH-EVENTS]], as a result of a touch or pen interaction.</p>
+            <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the user agent MUST NOT generate <em>both</em> the compatibility mouse events as described in this section, and the <a data-cite="touch-events/#mouse-events">fallback mouse events</a> outlined in [[TOUCH-EVENTS]].</p>
             <div class="note">
                 <p>The activation of an element (<code>click</code>) with a primary pointer that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (e.g. single finger on a touchscreen) would typically produce the following event sequence:</p>
                 <ol data-class="note-list">


### PR DESCRIPTION
x-ref https://github.com/w3c/pointerevents/issues/405


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/413.html" title="Last updated on Sep 30, 2021, 11:13 PM UTC (e7b9ba6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/413/76c9195...e7b9ba6.html" title="Last updated on Sep 30, 2021, 11:13 PM UTC (e7b9ba6)">Diff</a>