### PR TITLE
Remove redundant (and now wrong) note about active pointer id

### DIFF
--- a/index.html
+++ b/index.html
@@ -1402,7 +1402,6 @@ function tilt2spherical(tiltX, tiltY){
                         <li>If a touch contact or pen/stylus is lifted beyond the range of the digitizer, then it is no longer considered active.</li>
                     </ul>
                     <div class="note">On some platforms, the set of active pointers includes all pointer input to the device, including any that are not targeted at the user agent (e.g. those targeted at other applications).</div>
-                    <div class="note">Each active pointer should have the same id within the scope of the <a>top-level browsing context</a> (as defined by [[HTML]]). However, there is no such guarantee across multiple <a>top-level browsing contexts</a>.</div>
                 </dd>
             <dt><dfn>canceled event</dfn></dt>
                 <dd>An event whose default action was prevented by means of <code>preventDefault()</code>, returning <code>false</code> in an event handler, or other means as defined by [[UIEVENTS]] and [[HTML]].</dd>


### PR DESCRIPTION
x-ref https://github.com/w3c/pointerevents/issues/405


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/417.html" title="Last updated on Oct 13, 2021, 9:51 PM UTC (53c8489)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/417/d5e6171...53c8489.html" title="Last updated on Oct 13, 2021, 9:51 PM UTC (53c8489)">Diff</a>