### PR TITLE
Remove should from boundary events note and move to normative must.

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,9 +405,9 @@ interface PointerEvent : MouseEvent {
                 <p>If the event is <code>pointerdown</code>, the associated device is a direct manipulation device, and the target is an {{Element}},
                    then <a href="#setting-pointer-capture">set pointer capture</a> for this <code>pointerId</code> to the target element as described in <a>implicit pointer capture</a>.
 
-                <p>Fire the event to the determined target.
+                <p>Fire the event to the determined target. The user agent SHOULD treat the target as if the pointing device has moved over it for the purpose of <a href="uievents/#events-mouseevent-event-order">ensuring event ordering</a>.
 
-                <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events. This is the same as the pointer leaving its previous target and entering this new capturing target — and if they are different targets, boundary events should be dispatched first. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>
+                <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events. This is the same as the pointer leaving its previous target and entering this new capturing target. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>
 
                 <section>
                   <h3>Attributes and default actions</h3>

--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@ interface PointerEvent : MouseEvent {
 
                 <p>Fire the event to the determined target. The user agent SHOULD treat the target as if the pointing device has moved over it for the purpose of <a href="uievents/#events-mouseevent-event-order">ensuring event ordering</a>.
 
-                <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events. This is the same as the pointer leaving its previous target and entering this new capturing target. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>
+                <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events, as defined by [[UI-EVENTS]]. This is the same as the pointer leaving its previous target and entering this new capturing target. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>
 
                 <section>
                   <h3>Attributes and default actions</h3>


### PR DESCRIPTION
x-ref #405

Clarify in normative text that the target should be treated as if the pointing device moved over it, but defer whether boundary events should be fired to uievents.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/flackr/pointerevents/pull/419.html" title="Last updated on Dec 6, 2021, 10:02 AM UTC (6327b0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/419/ef3ea93...flackr:6327b0f.html" title="Last updated on Dec 6, 2021, 10:02 AM UTC (6327b0f)">Diff</a>