### PR TITLE
Reword altitudeAngle note, expand tiltX and tiltY explanation

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@ interface PointerEvent : MouseEvent {
                         </dd>
                     <dt><dfn>tiltX</dfn></dt>
                         <dd>
-                            <p>The plane angle (in degrees, in the range of [-90,90]) between the Y-Z plane and the plane containing both the transducer (e.g. pen/stylus) axis and the Y axis. A positive <code>tiltX</code> is to the right. <code>tiltX</code> can be used along with <code>tiltY</code> to represent the tilt away from the normal of a transducer with the digitizer. For hardware and platforms that do not report tilt or angle, the value MUST be 0.</p>
+                            <p>The plane angle (in degrees, in the range of [-90,90]) between the Y-Z plane and the plane containing both the transducer (e.g. pen/stylus) axis and the Y axis. A positive <code>tiltX</code> is to the right, in the direction of increasing X values. <code>tiltX</code> can be used along with <code>tiltY</code> to represent the tilt away from the normal of a transducer with the digitizer. For hardware and platforms that do not report tilt or angle, the value MUST be 0.</p>
                             <figure id="figure_tiltX">
                                 <img src="images/tiltX.png" alt="tiltX explanation diagram">
                                 <figcaption>Positive <code>tiltX</code>.</figcaption>
@@ -260,7 +260,7 @@ interface PointerEvent : MouseEvent {
                         </dd>
                     <dt><dfn>tiltY</dfn></dt>
                         <dd>
-                            <p>The plane angle (in degrees, in the range of [-90,90]) between the X-Z plane and the plane containing both the transducer (e.g. pen/stylus) axis and the X axis. A positive <code>tiltY</code> is towards the user. <code>tiltY</code> can be used along with <code>tiltX</code> to represent the tilt away from the normal of a transducer with the digitizer. For hardware and platforms that do not report tilt or angle, the value MUST be 0.</p>
+                            <p>The plane angle (in degrees, in the range of [-90,90]) between the X-Z plane and the plane containing both the transducer (e.g. pen/stylus) axis and the X axis. A positive <code>tiltY</code> is towards the user, in the direction of increasing Y values. <code>tiltY</code> can be used along with <code>tiltX</code> to represent the tilt away from the normal of a transducer with the digitizer. For hardware and platforms that do not report tilt or angle, the value MUST be 0.</p>
                             <figure id="figure_tiltY">
                                 <img src="images/tiltY.png" alt="tiltY explanation diagram">
                                 <figcaption>Positive <code>tiltY</code>.</figcaption>
@@ -274,10 +274,10 @@ interface PointerEvent : MouseEvent {
                         <dd>
                             <p>The altitude (in radians) of the transducer (e.g. pen/stylus), in the range [0,π/2] — where 0 is parallel to the surface (X-Y plane), and π/2 is perpendicular to the surface. For hardware and platforms that do not report tilt or angle, the value MUST be π/2.</p>
                             <div class="note">
-                                When the hardware or platform does not report the tilt or angle, as opposed to the default value of 0 defined for <code>altitudeAngle</code>
-                                in <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification,
-                                the default value defined here is π/2. This correlates with the default values of 0 for both <code>tiltX</code> and
-                                <code>tiltY</code> (when the hardware or platform do not report them) which positions the transducer as being perpendicular to the surface.
+                                When the hardware or platform does not report the tilt or angle, the default value defined here for <code>altitudeAngle</code> is π/2,
+                                which positions the transducer as being perpendicular to the surface.
+                                This differs from the default value of 0 defined in <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification.
+                                However, the perpendicular position does correspond to a default value of 0 for <code>tiltX</code>, <code>tiltY</code>, and <code>azimuthAngle</code>.
                             </div>
                             <figure id="figure_altitudeAngle">
                                 <img src="images/altitudeAngle.png" alt="altitudeAngle explanation diagram">


### PR DESCRIPTION
- the previous wording of the note was confusing - the sentence was back-to-front, and the "This correlates to" added to the confusion
- the "to the right" / "towards the user" wording for `tiltX` and `tiltY`, while correct, does not match the "increasing X values" wording used for `azimuthAngle`. This expands the definition, making it more comprehensive.

<s>One slight concern: because the coordinate system for on-screen values uses right-hand axes, and the default axes in 3D apps (which were used to make the diagrams) are left-hand axes, there's now a mismatch in the apparent direction of the Y axis - in the diagrams, it seems to imply that Y values increase when moving away from the user, not towards the user. The diagrams may have to be tweaked to have a right-hand coordinate system (if that's easy/possible to do)</s> RESOLVED: changed (and updated) the illustrations to remove this confusion https://github.com/w3c/pointerevents/pull/423


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/422.html" title="Last updated on Dec 6, 2021, 9:00 PM UTC (9aff1d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/422/a990261...9aff1d5.html" title="Last updated on Dec 6, 2021, 9:00 PM UTC (9aff1d5)">Diff</a>