### PR TITLE
Reword `altitudeAngle` note

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,10 +274,10 @@ interface PointerEvent : MouseEvent {
                         <dd>
                             <p>The altitude (in radians) of the transducer (e.g. pen/stylus), in the range [0,π/2] — where 0 is parallel to the surface (X-Y plane), and π/2 is perpendicular to the surface. For hardware and platforms that do not report tilt or angle, the value MUST be π/2.</p>
                             <div class="note">
-                                When the hardware or platform does not report the tilt or angle, the default value defined here for <code>altitudeAngle</code> is π/2,
+                                The default value defined here for <code>altitudeAngle</code> is π/2,
                                 which positions the transducer as being perpendicular to the surface.
-                                This differs from the default value of 0 defined in <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification.
-                                However, the perpendicular position does correspond to a default value of 0 for <code>tiltX</code>, <code>tiltY</code>, and <code>azimuthAngle</code>.
+                                This differs from the <a href="https://w3c.github.io/touch-events/">Touch Events - Level 2</a> specification's
+                                definition for the <code>altitudeAngle</code> property, which has a default value of 0.
                             </div>
                             <figure id="figure_altitudeAngle">
                                 <img src="images/altitudeAngle.png" alt="altitudeAngle explanation diagram">


### PR DESCRIPTION
follow-up to https://github.com/w3c/pointerevents/pull/422 to further clarify the note, and to remove the unnecessary "However..." sentence which just made things more confusing still.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/424.html" title="Last updated on Dec 8, 2021, 5:30 PM UTC (c85b83f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/424/d33bb2c...c85b83f.html" title="Last updated on Dec 8, 2021, 5:30 PM UTC (c85b83f)">Diff</a>