### PR TITLE
Event constructor issue 223

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,11 +963,13 @@ partial interface Navigator {
             </figure>
 
             <p>A <a>PointerEvent</a> has an associated <dfn>coalesced event list</dfn> (a list of
-            zero or more <code>PointerEvent</code>s). If this event is a <code>pointermove</code>
-            or <code>pointerrawupdate</code> event, the list is a sequence of all <code>PointerEvent</code>s
-            that were coalesced into this event; otherwise it is an empty list.</p>
+            zero or more <code>PointerEvent</code>s). If a trusted event is a <code>pointermove</code> or
+            <code>pointerrawupdate</code> event, the list is a sequence of all <code>PointerEvent</code>s
+            that were coalesced into this event; otherwise it is an empty list.
+            Untrusted events have their <a>coalesced event list</a> initialized to the value passed to the
+            constructor.</p>
 
-            <p>The events in the coalesced event list will have increasing
+            <p>The events in the coalesced event list of a trusted event will have increasing
             {{Event/timeStamp}}s, so the first event will have the smallest {{Event/timeStamp}}.</p>
 
             <pre id="example_10" class="example" title="Basic canvas drawing application using the coalesced events list">

--- a/index.html
+++ b/index.html
@@ -322,7 +322,11 @@ interface PointerEvent : MouseEvent {
                         </dd>
                 </dl>
 
-                <p>The <dfn>PointerEventInit</dfn> dictionary is used by the <dfn>PointerEvent</dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. The [=event constructing steps=] are defined in the [[[DOM]]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
+                <p>The <dfn>PointerEventInit</dfn> dictionary is used by the <dfn>PointerEvent</dfn> interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
+
+                <p>The [=event constructing steps=] for <dfn>PointerEvent</dfn>
+                   clones <a>PointerEventInit</a>'s <code>coalescedEvents</code> to <a>coalesced event list</a> and
+                   clones <a>PointerEventInit</a>'s <code>predictedEvents</code> to <a>predicted event list</a>.</p>
 
                 <div class="note">
                     <p>Pointer Events include two complementary sets of attributes to express the orientation of a
@@ -1061,7 +1065,8 @@ partial interface Navigator {
             <p>A <a>PointerEvent</a> has an associated <dfn>predicted event list</dfn> (a list of zero or more
             <code>PointerEvent</code>s). If this event is a <code>pointermove</code> event, it is a sequence of
             <code>PointerEvent</code>s that the user agent predicts will follow the events in the
-            <a>coalesced event list</a> in the future; otherwise it is an empty list.</p>
+            <a>coalesced event list</a> in the future; otherwise it is an empty list.
+            Untrusted events have their predicted event list initialized to the value passed to the constructor.</p>
             <div class="note">
                 <p>While <code>pointerrawmove</code> events may have a non-empty <a>coalesced event list</a>,
                 their <a>predicted event list</a> will, for performance reasons, usually be an empty list.</p>


### PR DESCRIPTION
x-ref https://github.com/w3c/pointerevents/issues/223


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/smaug----/pointerevents/pull/426.html" title="Last updated on Dec 22, 2021, 3:39 PM UTC (b59f658)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/426/cdb4a64...smaug----:b59f658.html" title="Last updated on Dec 22, 2021, 3:39 PM UTC (b59f658)">Diff</a>