### PR TITLE
Specify event constructing steps when coalesced/predicted events are passed using the PointerEventInit

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,7 +322,12 @@ interface PointerEvent : MouseEvent {
                         </dd>
                 </dl>
 
-                <p>The <dfn>PointerEventInit</dfn> dictionary is used by the {{PointerEvent}} interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. The [=event constructing steps=] are defined in the [[[DOM]]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
+                <p>The <dfn>PointerEventInit</dfn> dictionary is used by the {{PointerEvent}} interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
+
+                <p>The [=event constructing steps=] for <dfn>PointerEvent</dfn>
+                   clones <a>PointerEventInit</a>'s <code>coalescedEvents</code> to <a>coalesced event list</a> and
+                   clones <a>PointerEventInit</a>'s <code>predictedEvents</code> to <a>predicted event list</a>.</p>
+
 
                 <div class="note">The <code>PointerEvent</code> interface inherits from {{MouseEvent}}, defined in [[[UIEVENTS]]].
                     Also note the proposed extension in [[[CSSOM-VIEW]]], which changes the various coordinate properties from <code>long</code>

--- a/index.html
+++ b/index.html
@@ -325,8 +325,8 @@ interface PointerEvent : MouseEvent {
                 <p>The <dfn>PointerEventInit</dfn> dictionary is used by the {{PointerEvent}} interface's constructor to provide a mechanism by which to construct untrusted (synthetic) pointer events. It inherits from the {{MouseEventInit}} dictionary defined in [[UIEVENTS]]. See the <a href="#examples" title="examples">examples</a> for sample code demonstrating how to fire an untrusted pointer event.</p>
 
                 <p>The [=event constructing steps=] for <dfn>PointerEvent</dfn>
-                   clones <a>PointerEventInit</a>'s <code>coalescedEvents</code> to <a>coalesced event list</a> and
-                   clones <a>PointerEventInit</a>'s <code>predictedEvents</code> to <a>predicted event list</a>.</p>
+                   clones <a>PointerEventInit</a>'s <code><a data-lt="PointerEventInit.coalescedEvents">coalescedEvents</a></code> to <a>coalesced events list</a> and
+                   clones <a>PointerEventInit</a>'s <code><a data-lt="PointerEventInit.predictedEvents">predictedEvents</a></code> to <a>predicted events list</a>.</p>
 
 
                 <div class="note">The <code>PointerEvent</code> interface inherits from {{MouseEvent}}, defined in [[[UIEVENTS]]].


### PR DESCRIPTION
x-ref https://github.com/w3c/pointerevents/issues/223


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/smaug----/pointerevents/pull/427.html" title="Last updated on Jan 5, 2022, 4:27 PM UTC (63d0341)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/427/90b2fa5...smaug----:63d0341.html" title="Last updated on Jan 5, 2022, 4:27 PM UTC (63d0341)">Diff</a>