### PR TITLE
The `contextmenu` event is no longer defined in the HTML spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,9 +624,9 @@ interface PointerEvent : MouseEvent {
             </section>
             <section>
                 <h3>The <dfn><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</dfn></h3>
-                <p>This section is an addition to <a data-cite="uievents/#event-type-click">click</a> and
-                   <a data-cite="uievents/#event-type-auxclick">auxclick</a> events defined in [[UIEVENTS]] and
-                   [=HTMLElement/contextmenu=] defined in [[HTML]]. The type of these events MUST be <code>PointerEvent</code>,
+                <p>This section is an addition to <a data-cite="uievents/#event-type-click">click</a>,
+                   <a data-cite="uievents/#event-type-auxclick">auxclick</a> and <a data-cite="uievents/#event-type-contextmenu">contextmenu</a>
+                   events defined in [[UIEVENTS]]. The type of these events MUST be <code>PointerEvent</code>,
                    but the dispatch process is going to match that of the original specification.</p>
                    For these events, all <code>PointerEvent</code> specific attributes (defined in this spec) other than <code>pointerId</code> and <code>pointerType</code> will have their default values. In addition:</p>
                    <ul>


### PR DESCRIPTION
The reference to the `contextmenu` event in 4.2.12 links to the HTML spec, even though any non-editorial mentions of that event –but not the definition in the event list– were removed (apparently by mistake) in whatwg/html#2742. That event was subsequently added to the UI Events spec in w3c/uievents#279, and now the definition in the HTML spec's event list has been removed in whatwg/html#7506. This change updates the reference to link to the UI Events spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreubotella/pointerevents/pull/428.html" title="Last updated on Jan 19, 2022, 10:45 AM UTC (6f4637a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/428/ac55a60...andreubotella:6f4637a.html" title="Last updated on Jan 19, 2022, 10:45 AM UTC (6f4637a)">Diff</a>