### PR TITLE
Fix spelling of initialized

### DIFF
--- a/index.html
+++ b/index.html
@@ -1015,7 +1015,7 @@ partial interface Navigator {
                 &lt;/script&gt;</code>
             </pre>
 
-            <div class="note">The PointerEvent's attributes will be initalized in a way that best represents
+            <div class="note">The PointerEvent's attributes will be initialized in a way that best represents
             the events in the coalesced events list. The specific method by which user agents should do this is not covered by
             this specification.</div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caseymm/pointerevents/pull/430.html" title="Last updated on Jan 19, 2022, 9:22 PM UTC (a0abcd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/430/5f3d9f4...caseymm:a0abcd0.html" title="Last updated on Jan 19, 2022, 9:22 PM UTC (a0abcd0)">Diff</a>