### PR TITLE
Move click event to correct place in the non-normative note for expected event sequence on non-hover devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1230,11 +1230,11 @@ partial interface Navigator {
                     <li>Zero or more <code>pointermove</code> and <code>mousemove</code> events, depending on movement of the pointer</li>
                     <li><code>pointerup</code></li>
                     <li><code>mouseup</code></li>
-                    <li><code>click</code></li>
                     <li><code>pointerout</code></li>
                     <li><code>pointerleave</code></li>
                     <li><code>mouseout</code></li>
                     <li><code>mouseleave</code></li>
+                    <li><code>click</code></li>
                 </ol>
                 <p>If, however, the <code>pointerdown</code> event is <a data-lt="canceled event">canceled</a> during this interaction then the sequence of events would be:</p>
                 <ol data-class="note-list">
@@ -1246,11 +1246,11 @@ partial interface Navigator {
                     <li><code>pointerdown</code></li>
                     <li>Zero or more <code>pointermove</code> events, depending on movement of the pointer</li>
                     <li><code>pointerup</code></li>
-                    <li><code>click</code></li>
                     <li><code>pointerout</code></li>
                     <li><code>pointerleave</code></li>
                     <li><code>mouseout</code></li>
                     <li><code>mouseleave</code></li>
+                    <li><code>click</code></li>
                 </ol>
             </div>
         </section>


### PR DESCRIPTION
Closes https://github.com/w3c/pointerevents/issues/431


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/432.html" title="Last updated on Feb 7, 2022, 11:15 PM UTC (63f0634)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/432/1d9f4a9...63f0634.html" title="Last updated on Feb 7, 2022, 11:15 PM UTC (63f0634)">Diff</a>