### PR TITLE
Expand bullet about when `pointercancel` fires

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,7 +578,7 @@ interface PointerEvent : MouseEvent {
                 <h3>The <dfn data-lt="pointercancel"><code>pointercancel</code> event</dfn></h3>
                 <p>The user agent MUST <a>fire a pointer event</a> named <code>pointercancel</code> in the following circumstances:</p>
                 <ul>
-                    <li>The user agent has determined that a pointer is unlikely to continue to produce events (for example, because of a hardware event).</li>
+                    <li>The user agent has determined that a pointer is unlikely to continue to produce events (for example, because a user agent dialog or context menu was opened, or because of a hardware event due to the pointer input device disconnecting).</li>
                     <li>After having fired the <code>pointerdown</code> event, if the pointer is subsequently used to manipulate the page viewport (e.g. panning or zooming).
                      <div class="note">User agents can trigger panning or zooming through multiple pointer types (such as touch and pen),
                      and therefore the start of a pan or zoom action may result in the cancellation of various pointers, including pointers with different pointer types.


### PR DESCRIPTION
* explicitly mention context menus/dialogs
* give an example of what we mean by "hardware event"

Closes #407, closes #408


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/434.html" title="Last updated on Mar 1, 2022, 11:57 PM UTC (25022eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/434/c0a9694...25022eb.html" title="Last updated on Mar 1, 2022, 11:57 PM UTC (25022eb)">Diff</a>