### PR TITLE
Clarify that coalesced events list contain also a clone of the parent event

### DIFF
--- a/index.html
+++ b/index.html
@@ -966,7 +966,7 @@ partial interface Navigator {
             <p>A <a>PointerEvent</a> has an associated <dfn>coalesced events list</dfn> (a list of
             zero or more <code>PointerEvent</code>s). For trusted <code>pointermove</code> and
             <code>pointerrawupdate</code> events, the list is a sequence of all <code>PointerEvent</code>s
-            that were coalesced into this event, including a clone of the "parent" event itself.
+            that were coalesced into this event, or if no events were coalesced, it contains a clone of the "parent" event itself.
             For all other trusted event types, it is an empty list.
             Untrusted events have their <a>coalesced events list</a> initialized to the value passed to the
             constructor.</p>

--- a/index.html
+++ b/index.html
@@ -966,7 +966,8 @@ partial interface Navigator {
             <p>A <a>PointerEvent</a> has an associated <dfn>coalesced events list</dfn> (a list of
             zero or more <code>PointerEvent</code>s). For trusted <code>pointermove</code> and
             <code>pointerrawupdate</code> events, the list is a sequence of all <code>PointerEvent</code>s
-            that were coalesced into this event. For all other trusted event types, it is an empty list.
+            that were coalesced into this event, including a clone of the "parent" event itself.
+            For all other trusted event types, it is an empty list.
             Untrusted events have their <a>coalesced events list</a> initialized to the value passed to the
             constructor.</p>
 


### PR DESCRIPTION
Since the list below talks about "parent" event, perhaps just clarifying the sentence is actually enough here..

This PR is for https://github.com/w3c/pointerevents/issues/409


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/smaug----/pointerevents/pull/436.html" title="Last updated on Apr 13, 2022, 11:49 AM UTC (866d077)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/436/614dc2c...smaug----:866d077.html" title="Last updated on Apr 13, 2022, 11:49 AM UTC (866d077)">Diff</a>