### PR TITLE
Properties firing pointermove and pointerrawupdate

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,17 +561,18 @@ interface PointerEvent : MouseEvent {
             </section>
             <section>
                 <h3>The <dfn data-lt="pointermove" class="export"><code>pointermove</code></dfn> event</h3>
-                <p>The user agent MUST <a>fire a pointer event</a> named <code>pointermove</code> when a pointer changes button state.
-                Additionally one <code>pointermove</code> MUST be fired when pointer changes coordinates, pressure, tangential pressure, tilt, twist, or
-                contact geometry (e.g. <code>width</code> and <code>height</code>) and the circumstances produce no other pointer events defined in this specification. User agents MAY delay dispatch of the <code>pointermove</code> event (for instance, for performance reasons).
+                <p>The user agent MUST <a>fire a pointer event</a> named <code>pointermove</code> when a pointer changes any properties that don't fire
+                <code>pointerdown</code> or <code>pointerup</code> events.  This includes any changes to coordinates, pressure, tangential pressure,
+                tilt, twist, contact geometry (i.e. <code>width</code> and <code>height</code>) or <a>chorded buttons</a>.</p>
+                <p>User agents MAY delay dispatch of the <code>pointermove</code> event (for instance, for performance reasons).
                 The <a>coalesced events</a> information will be exposed via the <a data-lt="PointerEvent.getCoalescedEvents"><code>getCoalescedEvents()</code></a> method for the single dispatched <code>pointermove</code> event.
                 The final coordinates of such events should be used for finding the target of the event.</p>
             </section>
             <section>
                 <h3>The <dfn data-lt="pointerrawupdate" class="export"><code>pointerrawupdate</code></dfn> event</h3>
                 <p>The user agent MUST <a>fire a pointer event</a>
-                named <code>pointerrawupdate</code> only within a [=secure context=] when
-                a pointer's attributes (i.e. button state, coordinates, pressure, tangential pressure, tilt, twist, or contact geometry) change.</p>
+                named <code>pointerrawupdate</code>, and only do so within a [=secure context=], when a pointer changes any properties that don't fire
+                <code>pointerdown</code> or <code>pointerup</code> events.  See <code>pointermove</code> event for a list of such properties.</p>
                 <p>In contrast with <code>pointermove</code>, user agents SHOULD dispatch <code>pointerrawupdate</code> events as soon as possible
                 and as frequently as the JavaScript can handle the events.</p>
                 <p>The <code>target</code> of <code>pointerrawupdate</code> events might be different from the <code>pointermove</code> events


### PR DESCRIPTION
Clarify the properties for which pointermove and pointerrawupdate events fire.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mustaqahmed/pointerevents/pull/443.html" title="Last updated on Jun 8, 2022, 3:18 PM UTC (82904fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/443/3fb15cc...mustaqahmed:82904fc.html" title="Last updated on Jun 8, 2022, 3:18 PM UTC (82904fc)">Diff</a>