### PR TITLE
Add missing link to 'fire a pointer event' for pointercancel

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,7 +607,7 @@ interface PointerEvent : MouseEvent {
             </section>
             <section>
                 <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointercancel</dfn> event</h3>
-                <p>The user agent MUST fire a pointer event named {{GlobalEventHandlers/pointercancel}} when it detects a scenario to <a>suppress a pointer event stream</a>.</p>
+                <p>The user agent MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointercancel}} when it detects a scenario to <a>suppress a pointer event stream</a>.</p>
             </section>
             <section>
                 <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointerout</dfn> event</h3>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/pointerevents/pull/452.html" title="Last updated on Jul 6, 2022, 9:24 AM UTC (909fab4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/452/e0ca29b...dontcallmedom:909fab4.html" title="Last updated on Jul 6, 2022, 9:24 AM UTC (909fab4)">Diff</a>