### PR TITLE
Add `pointerrawupdate` to "Attributes and Default Actions" table

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,12 @@ interface PointerEvent : MouseEvent {
                                     <td>Varies: when the pointer is primary, all default actions of <code>mousemove</code></td>
                                 </tr>
                                 <tr>
+                                    <td>{{GlobalEventHandlers/pointerrawupdate}}</td>
+                                    <td>Yes</td>
+                                    <td>No</td>
+                                    <td>None</td>
+                                </tr>
+                                <tr>
                                     <td>{{GlobalEventHandlers/pointerup}}</td>
                                     <td>Yes</td>
                                     <td>Yes</td>


### PR DESCRIPTION
Closes https://github.com/w3c/pointerevents/issues/451


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/453.html" title="Last updated on Jul 6, 2022, 3:55 PM UTC (9e322ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/453/94828d1...9e322ae.html" title="Last updated on Jul 6, 2022, 3:55 PM UTC (9e322ae)">Diff</a>