### PR TITLE
Reorder events in the GlobalEventHandlers mixin definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -712,13 +712,13 @@ partial interface mixin GlobalEventHandlers {
 };
             </pre>
             <dl data-dfn-for="GlobalEventHandlers" data-link-for="GlobalEventHandlers">
-                <dt><dfn>ongotpointercapture</dfn></dt>
+                <dt><dfn>onpointerover</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/gotpointercapture}} event type.
+                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerover}} event type.
                 </dd>
-                <dt><dfn>onlostpointercapture</dfn></dt>
+                <dt><dfn>onpointerenter</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/lostpointercapture}} event type.
+                    The [=event handler IDL attribute=] for the <code>pointerenter</code> event type.
                 </dd>
                 <dt><dfn>onpointerdown</dfn></dt>
                 <dd>
@@ -728,6 +728,10 @@ partial interface mixin GlobalEventHandlers {
                 <dd>
                     The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointermove}} event type.
                 </dd>
+                <dt><dfn>onpointerrawupdate</dfn></dt>
+                <dd>
+                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerrawupdate}} event type.
+                </dd>
                 <dt><dfn>onpointerup</dfn></dt>
                 <dd>
                     The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerup}} event type.
@@ -736,21 +740,23 @@ partial interface mixin GlobalEventHandlers {
                 <dd>
                     The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointercancel}} event type.
                 </dd>
-                <dt><dfn>onpointerover</dfn></dt>
-                <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerover}} event type.
-                </dd>
+                
                 <dt><dfn>onpointerout</dfn></dt>
                 <dd>
                     The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerout}} event type.
                 </dd>
-                <dt><dfn>onpointerenter</dfn></dt>
-                <dd>
-                    The [=event handler IDL attribute=] for the <code>pointerenter</code> event type.
-                </dd>
+                
                 <dt><dfn>onpointerleave</dfn></dt>
                 <dd>
                     The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerleave}} event type.
+                </dd>
+                <dt><dfn>ongotpointercapture</dfn></dt>
+                <dd>
+                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/gotpointercapture}} event type.
+                </dd>
+                <dt><dfn>onlostpointercapture</dfn></dt>
+                <dd>
+                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/lostpointercapture}} event type.
                 </dd>
             </dl>
         </div>

--- a/index.html
+++ b/index.html
@@ -698,17 +698,17 @@ partial interface Element {
             <p>The following section describes extensions to the existing {{GlobalEventHandlers}} mixin to facilitate the event handler registration.</p>
             <pre class="idl">
 partial interface mixin GlobalEventHandlers {
-    attribute EventHandler ongotpointercapture;
-    attribute EventHandler onlostpointercapture;
+    attribute EventHandler onpointerover;
+    attribute EventHandler onpointerenter;
     attribute EventHandler onpointerdown;
     attribute EventHandler onpointermove;
     [SecureContext] attribute EventHandler onpointerrawupdate;
     attribute EventHandler onpointerup;
     attribute EventHandler onpointercancel;
-    attribute EventHandler onpointerover;
     attribute EventHandler onpointerout;
-    attribute EventHandler onpointerenter;
     attribute EventHandler onpointerleave;
+    attribute EventHandler ongotpointercapture;
+    attribute EventHandler onlostpointercapture;
 };
             </pre>
             <dl data-dfn-for="GlobalEventHandlers" data-link-for="GlobalEventHandlers">


### PR DESCRIPTION
follow same order as in "Attributes and Default Actions" table and the "Pointer Event types" section


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/455.html" title="Last updated on Jul 6, 2022, 6:55 PM UTC (6f451c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/455/99995e1...6f451c1.html" title="Last updated on Jul 6, 2022, 6:55 PM UTC (6f451c1)">Diff</a>