### PR TITLE
Move note about pointerup pressure of 0 to pointerup event explanation

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@ interface PointerEvent : MouseEvent {
                         </dd>
                     <dt><dfn>pressure</dfn></dt>
                         <dd>
-                            <p>The normalized pressure of the pointer input in the range of [0,1], where 0 and 1 represent the minimum and maximum pressure the hardware is capable of detecting, respectively. For hardware and platforms that do not support pressure, the value MUST be 0.5 when in the <a>active buttons state</a> and 0 otherwise. Note: all {{GlobalEventHandlers/pointerup}} events will have pressure 0.</p>
+                            <p>The normalized pressure of the pointer input in the range of [0,1], where 0 and 1 represent the minimum and maximum pressure the hardware is capable of detecting, respectively. For hardware and platforms that do not support pressure, the value MUST be 0.5 when in the <a>active buttons state</a> and 0 otherwise.</p>
                         </dd>
                     <dt><dfn>tangentialPressure</dfn></dt>
                         <dd>
@@ -609,6 +609,7 @@ interface PointerEvent : MouseEvent {
                 <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-event-type="event">pointerup</dfn> event</h3>
                 <p>The user agent MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerup}} when a pointer leaves the <a>active buttons state</a>. For mouse, this is when the device transitions from at least one button depressed to no buttons depressed. For touch, this is when physical contact is removed from the <a>digitizer</a>. For pen, this is when the pen is removed from the physical contact with the digitizer while no button is depressed, or transitions from at least one button depressed to no buttons depressed while hovering.</p>
                 <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the user agent MUST also <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerout}} followed by a pointer event named {{GlobalEventHandlers/pointerleave}} after dispatching the {{GlobalEventHandlers/pointerup}} event.</p>
+                <p>All {{GlobalEventHandlers/pointerup}} events have a <code>pressure</code> value of <code>0</code>.
                 <p>The user agent MUST also <a>implicitly release the pointer capture</a> if the pointer is currently captured.</p>
                 <div class="note">For mouse (or other multi-button pointer devices), this means {{GlobalEventHandlers/pointerdown}} and {{GlobalEventHandlers/pointerup}} are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a>chorded buttons</a> for more information.</div>
             </section>


### PR DESCRIPTION
As discussed in today's meeting https://www.w3.org/2023/03/01-pointerevents-minutes.html, this moves the note about `pointerup` always having a `pressure` of `0` to the actual `pointerup` explanation - for consistency with the approach taken for `pointercancel` in https://github.com/w3c/pointerevents/pull/464


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/466.html" title="Last updated on Mar 2, 2023, 12:32 AM UTC (a14ff6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/466/3ba7b34...a14ff6c.html" title="Last updated on Mar 2, 2023, 12:32 AM UTC (a14ff6c)">Diff</a>