### PR TITLE
Use `float` instead of `double` for `altitudeAngle` and `azimuthAngle`

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,8 +205,8 @@ dictionary PointerEventInit : MouseEventInit {
     long        tiltX;
     long        tiltY;
     long        twist = 0;
-    double      altitudeAngle;
-    double      azimuthAngle;
+    float       altitudeAngle;
+    float       azimuthAngle;
     DOMString   pointerType = "";
     boolean     isPrimary = false;
     sequence&lt;PointerEvent> coalescedEvents = [];
@@ -224,8 +224,8 @@ interface PointerEvent : MouseEvent {
     readonly        attribute long        tiltX;
     readonly        attribute long        tiltY;
     readonly        attribute long        twist;
-    readonly        attribute double      altitudeAngle;
-    readonly        attribute double      azimuthAngle;
+    readonly        attribute float       altitudeAngle;
+    readonly        attribute float       azimuthAngle;
     readonly        attribute DOMString   pointerType;
     readonly        attribute boolean     isPrimary;
     [SecureContext] sequence&lt;PointerEvent> getCoalescedEvents();


### PR DESCRIPTION
Altitude angle and azimuth angle are computed always computed with 32-bit floating points. For example, on macOS, https://developer.apple.com/documentation/appkit/nsevent/1534226-tilt. A priori, using a double doesn't offer more precision.

[EDIT: On macOS, the NSPoint struct uses `double` when the OS is x64, so this implies double accuracy is correct]


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrandolf/pointerevents/pull/485.html" title="Last updated on Oct 9, 2023, 1:06 AM UTC (305c9ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/485/3943f69...jrandolf:305c9ac.html" title="Last updated on Oct 9, 2023, 1:06 AM UTC (305c9ac)">Diff</a>