### PR TITLE
Handle pointer capture node removal asynchronously

### DIFF
--- a/index.html
+++ b/index.html
@@ -1096,14 +1096,14 @@ partial interface Navigator {
                 if the pointer supports hover, user agent MUST also send corresponding boundary events necessary
                 to reflect the current position of the pointer with no capture.</p>
             <p>When the <a>pointer capture target override</a> is no longer [=connected=] [[DOM]],
-                the <a>pending pointer capture target override</a> node SHOULD be cleared and
                 the <a>pointer capture target override</a> SHOULD be set to the document.</p>
-                <div class="note">
-                    This will result in a {{GlobalEventHandlers/lostpointercapture}} event corresponding to the captured pointer being fired at the document
-                    during the next <a>Process pending pointer capture</a>.
-                </div>
             <p>When the <a>pending pointer capture target override</a> is no longer [=connected=] [[DOM]],
                 the <a>pending pointer capture target override</a> node SHOULD be cleared.</p>
+            <div class="note">
+                The previous two paragraphs result in a {{GlobalEventHandlers/lostpointercapture}} event
+                corresponding to the captured pointer being fired at the document
+                during the next <a>Process pending pointer capture</a> after the capture node is removed.
+            </div>
             <p>When a pointer lock [[PointerLock]] is successfully applied on an element, the user agent MUST run the steps as if the <a data-lt='Element.releasePointerCapture'>releasePointerCapture()</a> method has been called if any element is set to be captured or pending to be captured.
 
         </section>

--- a/index.html
+++ b/index.html
@@ -1096,8 +1096,14 @@ partial interface Navigator {
                 if the pointer supports hover, user agent MUST also send corresponding boundary events necessary
                 to reflect the current position of the pointer with no capture.</p>
             <p>When the <a>pointer capture target override</a> is no longer [=connected=] [[DOM]],
-                the <a>pending pointer capture target override</a> and <a>pointer capture target override</a> nodes SHOULD be cleared
-                and also a PointerEvent named {{GlobalEventHandlers/lostpointercapture}} corresponding to the captured pointer SHOULD be fired at the document.</p>
+                the <a>pending pointer capture target override</a> node SHOULD be cleared and
+                the <a>pointer capture target override</a> SHOULD be set to the document.</p>
+                <div class="note">
+                    This will result in a {{GlobalEventHandlers/lostpointercapture}} event corresponding to the captured pointer being fired at the document
+                    during the next <a>Process pending pointer capture</a>.
+                </div>
+            <p>When the <a>pending pointer capture target override</a> is no longer [=connected=] [[DOM]],
+                the <a>pending pointer capture target override</a> node SHOULD be cleared.</p>
             <p>When a pointer lock [[PointerLock]] is successfully applied on an element, the user agent MUST run the steps as if the <a data-lt='Element.releasePointerCapture'>releasePointerCapture()</a> method has been called if any element is set to be captured or pending to be captured.
 
         </section>


### PR DESCRIPTION
This explains what happens when the current pointer capture target is removed or the pending pointer capture target is removed - addressing the concern raised in #487. The pointer capture is updated during the next process pending pointer capture which occurs before the dispatch of the next pointer event.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/flackr/pointerevents/pull/490.html" title="Last updated on Nov 2, 2023, 6:36 PM UTC (fc7616e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/490/24de93c...flackr:fc7616e.html" title="Last updated on Nov 2, 2023, 6:36 PM UTC (fc7616e)">Diff</a>