### PR TITLE
Explain how a removed DOM node should be handled for boundary events.

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,17 @@ interface PointerEvent : MouseEvent {
                 <p>If the event is {{GlobalEventHandlers/pointerdown}}, the associated device is a direct manipulation device, and the target is an {{Element}},
                     then <a>set pointer capture</a> for this <code>pointerId</code> to the target element as described in <a>implicit pointer capture</a>.
 
-                <p>Fire the event to the determined target. The user agent SHOULD treat the target as if the pointing device has moved over it for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]].</p>
+                <p>Fire the event to the determined target.
+                    The user agent SHOULD treat the target as if the pointing device has moved over it from the |previous target| (or if the |over child| flag is set, over an anonymous child of |previous target|)
+                    for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]].</p>
+
+                <p>Save the determined target as the |previous target| for the given pointer,
+                    and reset the |over child| flag to <code>false</code>.
+                    If the |previous target| at any point will no longer be [=connected=] [[DOM]],
+                    update the |previous target| to the nearest still [=connected=] [[DOM]] parent
+                    following the event path corresponding to dispatching events to the previous target,
+                    and set the |over child| flag to <code>true</code>.
+                </p>
 
                 <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events, as defined by [[UIEVENTS]]. This is the same as the pointer leaving its previous target and entering this new capturing target. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>
 

--- a/index.html
+++ b/index.html
@@ -424,15 +424,17 @@ interface PointerEvent : MouseEvent {
                     then <a>set pointer capture</a> for this <code>pointerId</code> to the target element as described in <a>implicit pointer capture</a>.
 
                 <p>Fire the event to the determined target.
-                    The user agent SHOULD treat the target as if the pointing device has moved over it from the |previous target| (or if the |over child| flag is set, over an anonymous child of |previous target|)
-                    for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]].</p>
+                    The user agent SHOULD treat the target as if the pointing device has moved over it from the |previous target|
+                    for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]].
+                    If the |needs over event| flag is set, an over event is needed even if the target element is the same.
+                </p>
 
                 <p>Save the determined target as the |previous target| for the given pointer,
-                    and reset the |over child| flag to <code>false</code>.
+                    and reset the |needs over event| flag to <code>false</code>.
                     If the |previous target| at any point will no longer be [=connected=] [[DOM]],
                     update the |previous target| to the nearest still [=connected=] [[DOM]] parent
                     following the event path corresponding to dispatching events to the previous target,
-                    and set the |over child| flag to <code>true</code>.
+                    and set the |needs over event| flag to <code>true</code>.
                 </p>
 
                 <div class="note">Using the <a>pointer capture target override</a> as the target instead of the normal hit-test result may fire some boundary events, as defined by [[UIEVENTS]]. This is the same as the pointer leaving its previous target and entering this new capturing target. When the capture is released, the same scenario may happen, as the pointer is leaving the capturing target and entering the hit-test target.</div>


### PR DESCRIPTION
This explains how the previous target is tracked when the previous target is removed from the DOM for #477.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/flackr/pointerevents/pull/491.html" title="Last updated on Nov 20, 2023, 7:41 PM UTC (6a69eda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/491/24de93c...flackr:6a69eda.html" title="Last updated on Nov 20, 2023, 7:41 PM UTC (6a69eda)">Diff</a>