### PR TITLE
Clarify what happens with a failed pointer capture set/release.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1166,6 +1166,7 @@ partial interface Navigator {
                     the |element|'s [=Node/node document=] is not the <a>active document</a> of the |pointer|, then terminate these steps.</li>
                 <li>For the specified <code>pointerId</code>, set the <dfn>pending pointer capture target override</dfn> to the {{Element}} on which this method was invoked.</li>
             </ol>
+            <div class="note">If a call to set or release a pointer capture is made while a previous set or release call is in a pending state (see <a>process pending pointer capture</a>), the second call overrides the first call if the second call is successful, otherwise the first call remains effective.  This is true for a failed attempt to release an <a>implicit pointer capture</a> at a {{GlobalEventHandlers/pointerdown}} listener.</div>
         </section>
 
         <section>
@@ -1176,6 +1177,7 @@ partial interface Navigator {
                 <li>If <a data-lt="Element.hasPointerCapture">hasPointerCapture</a> is false for the {{Element}} with the specified <code>pointerId</code>, then terminate these steps.</li>
                 <li>For the specified <code>pointerId</code>, clear the <a>pending pointer capture target override</a>, if set.</li>
             </ol>
+            <div class="note">See the note in the section <a>Setting pointer capture</a>.</div>
         </section>
 
         <section>


### PR DESCRIPTION
Fixes #534.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mustaqahmed/pointerevents/pull/537.html" title="Last updated on Feb 12, 2025, 3:12 PM UTC (8a9edbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/537/7a88278...mustaqahmed:8a9edbe.html" title="Last updated on Feb 12, 2025, 3:12 PM UTC (8a9edbe)">Diff</a>