### PR TITLE
Clarify what it means to suppress a pointer event stream.

### DIFF
--- a/index.html
+++ b/index.html
@@ -579,7 +579,7 @@ interface PointerEvent : MouseEvent {
 
                 <section>
                     <h4>Suppressing a pointer event stream</h4>
-                    <p>The user agent MUST <dfn>suppress a pointer event stream</dfn> when it detects that the web page is unlikely to continue to receive pointer events with a specific <code>pointerId</code>.  Any of the following scenarios satisfy this condition (there MAY be additional scenarios):</p>
+                    <p>The user agent MUST <dfn>suppress a pointer event stream</dfn> when it detects that the web page is unlikely to continue to receive pointer events with a specific <code>pointerId</code>. Any of the following scenarios satisfy this condition (there MAY be additional scenarios):</p>
                     <ul>
                         <li>The user agent has opened a modal dialog or menu.</li>
                         <li>A pointer input device is physically disconnected, or a hoverable pointer input device (e.g. a hoverable pen/stylus) has left the hover range detectable by the digitizer.</li>

--- a/index.html
+++ b/index.html
@@ -579,7 +579,7 @@ interface PointerEvent : MouseEvent {
 
                 <section>
                     <h4>Suppressing a pointer event stream</h4>
-                    <p>The user agent MUST <dfn>suppress a pointer event stream</dfn> when it detects that a pointer is unlikely to continue to produce events.  Any of the following scenarios satisfy this condition (there MAY be additional scenarios):</p>
+                    <p>The user agent MUST <dfn>suppress a pointer event stream</dfn> when it detects that the web page is unlikely to continue to receive pointer events with a specific <code>pointerId</code>.  Any of the following scenarios satisfy this condition (there MAY be additional scenarios):</p>
                     <ul>
                         <li>The user agent has opened a modal dialog or menu.</li>
                         <li>A pointer input device is physically disconnected, or a hoverable pointer input device (e.g. a hoverable pen/stylus) has left the hover range detectable by the digitizer.</li>


### PR DESCRIPTION
Fixes #504.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mustaqahmed/pointerevents/pull/539.html" title="Last updated on Mar 12, 2025, 9:38 AM UTC (b1ff048)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/539/6543e6b...mustaqahmed:b1ff048.html" title="Last updated on Mar 12, 2025, 9:38 AM UTC (b1ff048)">Diff</a>