### PR TITLE
touch-action canonical order and animation type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1037,11 +1037,13 @@ partial interface Navigator {
                 <tr><th>Name:</th><td><code>touch-action</code></td></tr>
                 <tr><th>Value:</th><td><code>auto</code> | <code>none</code> | [ [ <code>pan-x</code> | <code>pan-left</code> | <code>pan-right</code> ] || [ <code>pan-y</code> | <code>pan-up</code> | <code>pan-down</code> ] ] | <code>manipulation</code></td></tr>
                 <tr><th>Initial:</th><td><code>auto</code></td></tr>
-                <tr><th>Applies to:</th><td>all elements except: non-replaced inline elements, table rows, row groups, table columns, and column groups.</td></tr>
+                <tr><th>Applies to:</th><td>all elements except: non-replaced inline elements, table rows, row groups, table columns, and column groups</td></tr>
                 <tr><th>Inherited:</th><td>no</td></tr>
                 <tr><th>Percentages:</th><td>N/A</td></tr>
                 <tr><th>Media:</th><td>visual</td></tr>
-                <tr><th>Computed value:</th><td>Same as specified value.</td></tr>
+                <tr><th>Computed value:</th><td>same as specified value</td></tr>
+                <tr><th>Canonical order:</th><td>per grammar</td></tr>
+                <tr><th>Animation type:</th><td>not animatable</td></tr>
             </table>
 
             <p>The <code>touch-action</code> CSS property determines whether <a>direct manipulation</a> interactions (which are not limited to touch, despite the property's name) MAY trigger the user agent's panning and zooming behavior. See the section on <a><code>touch-action</code> values</a>.</p>


### PR DESCRIPTION
CSS properties  should define their [canonical order](https://www.w3.org/TR/cssom/#serializing-css-values) and [animation type](https://www.w3.org/TR/web-animations/#animation-type).

Proposal for touch-action:
* canonical order is per grammar 
* animation type is not animatable


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/546.html" title="Last updated on May 1, 2025, 3:01 PM UTC (71ee22e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/546/dcff59f...71ee22e.html" title="Last updated on May 1, 2025, 3:01 PM UTC (71ee22e)">Diff</a>