### PR TITLE
WebDriver BiDi emulated max touch points

### DIFF
--- a/index.html
+++ b/index.html
@@ -1019,8 +1019,22 @@ partial interface Navigator {
 </pre>
             <dl data-dfn-for="Navigator" data-link-for="Navigator">
                 <dt><dfn>maxTouchPoints</dfn></dt>
-                <dd><p>The maximum number of simultaneous touch contacts supported by the device. In the case of devices with multiple digitizers (e.g. multiple touchscreens), the value MUST be the maximum of the set of maximum supported contacts by each individual digitizer.</p>
-                <p>For example, suppose a device has 3 touchscreens, which support 2, 5, and 10 simultaneous touch contacts, respectively. The value of <code>maxTouchPoints</code> should be <code>10</code>.</p>
+                <dd><p>The getter steps are:
+                    <ol>
+                        <li>Let |emulated maxTouchPoints| be the result of
+                          <a data-cite="WEBDRIVER-BIDI#webdriver-bidi-emulated-max-touch-points">WebDriver BiDi emulated max touch points</a>
+                          [[!WEBDRIVER-BIDI]].</li>
+                        <li>If |emulated maxTouchPoints| is not null, return
+                            |emulated maxTouchPoints|.</li>
+                        <li><p>Return the maximum number of simultaneous touch contacts supported by
+                            the device. In the case of devices with multiple digitizers (e.g.
+                            multiple touchscreens), the value MUST be the maximum of the set of
+                            maximum supported contacts by each individual digitizer.</p>
+                            <p>For example, suppose a device has 3 touchscreens, which support 2, 5,
+                                and 10 simultaneous touch contacts, respectively. The value of
+                                <code>maxTouchPoints</code> should be <code>10</code>.</p>
+                        </li>
+                    </ol>
                 </dd>
             </dl>
             <div class="note">While a <code>maxTouchPoints</code> value of greater than <code>0</code> indicates the user's device is capable of supporting touch input, it does not necessarily mean the user <em>will</em> use touch input. Authors should be careful to also consider other input modalities that could be present on the system, such as mouse, pen, or screen readers.</div>


### PR DESCRIPTION
Allow for emulating `navigator.maxTouchPoints` on devices not supporting touch events. Respect ["WebDriver BiDi emulated max touch points"](https://github.com/w3c/webdriver-bidi/pull/1042) if provided.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/pointerevents/pull/561.html" title="Last updated on Dec 16, 2025, 2:29 PM UTC (97ba878)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/561/eebe6da...sadym-chromium:97ba878.html" title="Last updated on Dec 16, 2025, 2:29 PM UTC (97ba878)">Diff</a>