### PR TITLE
Pointerevents+UI events

### DIFF
--- a/images/stacked-event-mouse-dispatch.svg
+++ b/images/stacked-event-mouse-dispatch.svg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="450"
+   height="250"
+   id="svg3055"
+   version="1.1"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="stacked-event-mouse-dispatch.svg">
+  <defs
+     id="defs3057">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible">
+      <path
+         id="path3868"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Send"
+       style="overflow:visible">
+      <path
+         id="path3874"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Sstart"
+       style="overflow:visible">
+      <path
+         id="path3871"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path3859"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible">
+      <path
+         id="path3862"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.4241037"
+     inkscape:cx="249.79924"
+     inkscape:cy="93.563482"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6687"
+     showgrid="true"
+     inkscape:snap-grids="false"
+     inkscape:window-width="1307"
+     inkscape:window-height="769"
+     inkscape:window-x="39"
+     inkscape:window-y="18"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5852"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3060">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-802.36215)">
+    <g
+       id="g6687"
+       transform="translate(-137.85701,285.22141)">
+      <rect
+         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
+         y="624.36774"
+         x="161.86768"
+         height="142.3958"
+         width="293.22079"
+         id="rect3074"
+         style="fill:#ed1c24;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         style="fill:#ff7f27;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect3844"
+         width="293.22079"
+         height="142.3958"
+         x="193.17656"
+         y="607.86884"
+         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)" />
+      <rect
+         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
+         y="591.36993"
+         x="224.48544"
+         height="142.3958"
+         width="293.22079"
+         id="rect3846"
+         style="fill:#ffc90e;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="rect3848"
+         d="m 474.36088,766.92516 -312.4932,-0.16163"
+         style="fill:none;stroke:#000000;stroke-width:3.00159025;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker-start:url(#Arrow1Sstart);marker-end:none"
+         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)" />
+      <path
+         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
+         inkscape:transform-center-y="-72.537078"
+         inkscape:transform-center-x="4.2658296"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="rect3851"
+         d="M 161.86768,766.76353 161.56451,608.83611"
+         style="fill:none;stroke:#000000;stroke-width:3.00159025;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker-end:url(#Arrow1Send)" />
+      <path
+         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
+         style="fill:none;stroke:#000000;stroke-width:3.00159025;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker-start:none;marker-end:url(#Arrow1Send)"
+         d="M 161.86768,766.76353 280.67401,703.52016"
+         id="path3854"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-x="4.2658296"
+         inkscape:transform-center-y="-72.537078" />
+      <g
+         transform="translate(62.521417,173.44651)"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
+         id="flowRoot5792">
+        <path
+           d="m 459.16797,552.50235 -1.38867,0 -1.85743,-2.51367 -1.86914,2.51367 -1.2832,0 2.55469,-3.26367 -2.53125,-3.28125 1.38867,0 1.8457,2.47265 1.85157,-2.47265 1.28906,0 -2.57227,3.22265 2.57227,3.32227"
+           style="font-family:Verdana;-inkscape-font-specification:Verdana"
+           id="path3826" />
+      </g>
+      <g
+         transform="translate(-134.95825,134.05425)"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
+         id="flowRoot5792-7">
+        <path
+           d="m 458.64648,552.50235 -5.28515,0 0,-0.81446 3.81445,-4.81054 -3.73242,0 0,-0.91992 5.10351,0 0,0.78515 -3.83203,4.82813 3.93164,0 0,0.93164"
+           style="font-family:Verdana;-inkscape-font-specification:Verdana"
+           id="path3823" />
+      </g>
+      <g
+         transform="translate(-264.03472,53.717591)"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
+         id="flowRoot5792-1">
+        <path
+           d="m 459.16211,545.95743 -3.82031,8.95898 -1.17774,0 1.21875,-2.73047 -2.60742,-6.22851 1.19531,0 2.00977,4.85156 2.02734,-4.85156 1.1543,0"
+           style="font-family:Verdana;-inkscape-font-specification:Verdana"
+           id="path3820" />
+      </g>
+      <text
+         sodipodi:linespacing="125%"
+         id="text5840"
+         y="723.95667"
+         x="225.5477"
+         style="font-size:12px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+         xml:space="preserve"><tspan
+           style="font-size:24px;font-weight:bold;-inkscape-font-specification:Verdana Bold;font-family:Verdana;font-style:normal;font-stretch:normal;font-variant:normal"
+           y="723.95667"
+           x="225.5477"
+           id="tspan5842"
+           sodipodi:role="line">A</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-size:12px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+         x="255.5477"
+         y="703.95667"
+         id="text5844"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan5846"
+           x="255.5477"
+           y="703.95667"
+           style="font-size:24px;font-weight:bold;-inkscape-font-specification:Verdana Bold;font-family:Verdana;font-style:normal;font-stretch:normal;font-variant:normal">B</tspan></text>
+      <text
+         sodipodi:linespacing="125%"
+         id="text5848"
+         y="683.95667"
+         x="285.5477"
+         style="font-size:12px;font-style:normal;font-weight:bold;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana Bold;font-stretch:normal;font-variant:normal"
+         xml:space="preserve"><tspan
+           style="font-size:24px;font-weight:bold;-inkscape-font-specification:Verdana Bold;font-family:Verdana;font-style:normal;font-stretch:normal;font-variant:normal"
+           y="683.95667"
+           x="285.5477"
+           id="tspan5850"
+           sodipodi:role="line">C</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path6301"
+         d="m 320.53771,606.00922 0,28 2,0 0,-2 2,0 0,-2 2,0 0,-2 2,0 0,2 2,0 0,4 2,0 0,4 4,0 0,-4 -2,0 0,-4 -2,0 0,-4 8,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 z"
+         style="fill:#000000;fill-opacity:1;stroke:none" />
+      <path
+         style="fill:#808080;fill-opacity:1;stroke:none"
+         d="m 162.55349,691.72408 0,28 2,0 0,-2 2,0 0,-2 2,0 0,-2 2,0 0,2 2,0 0,4 2,0 0,4 4,0 0,-4 -2,0 0,-4 -2,0 0,-4 8,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 z"
+         id="path6303"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path6305"
+         d="m 164.90553,688.69292 c 29.2439,-38.65571 82.12691,-77.34202 152.40746,-83.72862"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:2, 4;stroke-dashoffset:0;marker-end:url(#Arrow1Mend)" />
+    </g>
+  </g>
+</svg>

--- a/images/stacked-event-mouse-dispatch.svg
+++ b/images/stacked-event-mouse-dispatch.svg
@@ -1,268 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="450"
-   height="250"
-   id="svg3055"
-   version="1.1"
-   inkscape:version="0.48.2 r9819"
-   sodipodi:docname="stacked-event-mouse-dispatch.svg">
-  <defs
-     id="defs3057">
-    <marker
-       inkscape:stockid="Arrow1Mend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Mend"
-       style="overflow:visible">
-      <path
-         id="path3868"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
-         transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         inkscape:connector-curvature="0" />
+<svg xmlns="http://www.w3.org/2000/svg" width="450" height="250" version="1.1">
+   <style>
+   text {
+      font-family: sans-serif;
+      font-weight: bold;
+      font-size: 18px;
+      fill:#000000;
+      fill-opacity:1;
+   }
+   @media (prefers-color-scheme: dark) {
+      svg {
+         filter: invert(100%);
+      }
+   }
+   </style>
+  <defs>
+    <marker orient="auto" refY="0" refX="0" id="m1" style="overflow:visible">
+      <path d="M 0,0 5,-5 -12.5,0 5,5 0,0 z" style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none" transform="matrix(0.2,0,0,0.2,1.2,0)" />
     </marker>
-    <marker
-       inkscape:stockid="Arrow1Send"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Send"
-       style="overflow:visible">
-      <path
-         id="path3874"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
-         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:stockid="Arrow1Sstart"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Sstart"
-       style="overflow:visible">
-      <path
-         id="path3871"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
-         transform="matrix(0.2,0,0,0.2,1.2,0)"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:stockid="Arrow1Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Lstart"
-       style="overflow:visible">
-      <path
-         id="path3859"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:stockid="Arrow1Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Lend"
-       style="overflow:visible">
-      <path
-         id="path3862"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         inkscape:connector-curvature="0" />
+    <marker orient="auto" refY="0" refX="0" id="m2" style="overflow:visible">
+      <path d="M 0,0 5,-5 -12.5,0 5,5 0,0 z" style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none" transform="matrix(-0.4,0,0,-0.4,-4,0)" />
     </marker>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="2.4241037"
-     inkscape:cx="249.79924"
-     inkscape:cy="93.563482"
-     inkscape:document-units="px"
-     inkscape:current-layer="g6687"
-     showgrid="true"
-     inkscape:snap-grids="false"
-     inkscape:window-width="1307"
-     inkscape:window-height="769"
-     inkscape:window-x="39"
-     inkscape:window-y="18"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid5852"
-       empspacing="5"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata3060">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-802.36215)">
-    <g
-       id="g6687"
-       transform="translate(-137.85701,285.22141)">
-      <rect
-         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
-         y="624.36774"
-         x="161.86768"
-         height="142.3958"
-         width="293.22079"
-         id="rect3074"
-         style="fill:#ed1c24;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <rect
-         style="fill:#ff7f27;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-         id="rect3844"
-         width="293.22079"
-         height="142.3958"
-         x="193.17656"
-         y="607.86884"
-         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)" />
-      <rect
-         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
-         y="591.36993"
-         x="224.48544"
-         height="142.3958"
-         width="293.22079"
-         id="rect3846"
-         style="fill:#ffc90e;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="rect3848"
-         d="m 474.36088,766.92516 -312.4932,-0.16163"
-         style="fill:none;stroke:#000000;stroke-width:3.00159025;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker-start:url(#Arrow1Sstart);marker-end:none"
-         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)" />
-      <path
-         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
-         inkscape:transform-center-y="-72.537078"
-         inkscape:transform-center-x="4.2658296"
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="rect3851"
-         d="M 161.86768,766.76353 161.56451,608.83611"
-         style="fill:none;stroke:#000000;stroke-width:3.00159025;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker-end:url(#Arrow1Send)" />
-      <path
-         transform="matrix(0.9935932,-0.11301575,0.06717403,0.99774127,0,0)"
-         style="fill:none;stroke:#000000;stroke-width:3.00159025;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker-start:none;marker-end:url(#Arrow1Send)"
-         d="M 161.86768,766.76353 280.67401,703.52016"
-         id="path3854"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cc"
-         inkscape:transform-center-x="4.2658296"
-         inkscape:transform-center-y="-72.537078" />
-      <g
-         transform="translate(62.521417,173.44651)"
-         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-         id="flowRoot5792">
-        <path
-           d="m 459.16797,552.50235 -1.38867,0 -1.85743,-2.51367 -1.86914,2.51367 -1.2832,0 2.55469,-3.26367 -2.53125,-3.28125 1.38867,0 1.8457,2.47265 1.85157,-2.47265 1.28906,0 -2.57227,3.22265 2.57227,3.32227"
-           style="font-family:Verdana;-inkscape-font-specification:Verdana"
-           id="path3826" />
-      </g>
-      <g
-         transform="translate(-134.95825,134.05425)"
-         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-         id="flowRoot5792-7">
-        <path
-           d="m 458.64648,552.50235 -5.28515,0 0,-0.81446 3.81445,-4.81054 -3.73242,0 0,-0.91992 5.10351,0 0,0.78515 -3.83203,4.82813 3.93164,0 0,0.93164"
-           style="font-family:Verdana;-inkscape-font-specification:Verdana"
-           id="path3823" />
-      </g>
-      <g
-         transform="translate(-264.03472,53.717591)"
-         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-         id="flowRoot5792-1">
-        <path
-           d="m 459.16211,545.95743 -3.82031,8.95898 -1.17774,0 1.21875,-2.73047 -2.60742,-6.22851 1.19531,0 2.00977,4.85156 2.02734,-4.85156 1.1543,0"
-           style="font-family:Verdana;-inkscape-font-specification:Verdana"
-           id="path3820" />
-      </g>
-      <text
-         sodipodi:linespacing="125%"
-         id="text5840"
-         y="723.95667"
-         x="225.5477"
-         style="font-size:12px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
-         xml:space="preserve"><tspan
-           style="font-size:24px;font-weight:bold;-inkscape-font-specification:Verdana Bold;font-family:Verdana;font-style:normal;font-stretch:normal;font-variant:normal"
-           y="723.95667"
-           x="225.5477"
-           id="tspan5842"
-           sodipodi:role="line">A</tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-size:12px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
-         x="255.5477"
-         y="703.95667"
-         id="text5844"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           id="tspan5846"
-           x="255.5477"
-           y="703.95667"
-           style="font-size:24px;font-weight:bold;-inkscape-font-specification:Verdana Bold;font-family:Verdana;font-style:normal;font-stretch:normal;font-variant:normal">B</tspan></text>
-      <text
-         sodipodi:linespacing="125%"
-         id="text5848"
-         y="683.95667"
-         x="285.5477"
-         style="font-size:12px;font-style:normal;font-weight:bold;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana Bold;font-stretch:normal;font-variant:normal"
-         xml:space="preserve"><tspan
-           style="font-size:24px;font-weight:bold;-inkscape-font-specification:Verdana Bold;font-family:Verdana;font-style:normal;font-stretch:normal;font-variant:normal"
-           y="683.95667"
-           x="285.5477"
-           id="tspan5850"
-           sodipodi:role="line">C</tspan></text>
-      <path
-         inkscape:connector-curvature="0"
-         id="path6301"
-         d="m 320.53771,606.00922 0,28 2,0 0,-2 2,0 0,-2 2,0 0,-2 2,0 0,2 2,0 0,4 2,0 0,4 4,0 0,-4 -2,0 0,-4 -2,0 0,-4 8,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 z"
-         style="fill:#000000;fill-opacity:1;stroke:none" />
-      <path
-         style="fill:#808080;fill-opacity:1;stroke:none"
-         d="m 162.55349,691.72408 0,28 2,0 0,-2 2,0 0,-2 2,0 0,-2 2,0 0,2 2,0 0,4 2,0 0,4 4,0 0,-4 -2,0 0,-4 -2,0 0,-4 8,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 z"
-         id="path6303"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path6305"
-         d="m 164.90553,688.69292 c 29.2439,-38.65571 82.12691,-77.34202 152.40746,-83.72862"
-         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:2, 4;stroke-dashoffset:0;marker-end:url(#Arrow1Mend)" />
-    </g>
+  <g id='main'>
+   <rect x="0" y="0" width="450" height="250" style="fill:white;fill-opacity:1;stroke:none" />
+   <path d="M 65,88 L 356,55 L 366,197 L 74,230 Z" style="fill:#ed1c24;fill-opacity:1;" />
+   <text style="font-size:24px;" x="80" y="210">A</text>
+   <path d="M 95,68 L 386,35 L 396,177 L 104,210 Z" style="fill:#ff7f27;fill-opacity:1;" />
+   <text style="font-size:24px;" x="110" y="190">B</text>
+   <path d="M 125,48 L 416,15 L 426,157 L 134,190 Z" style="fill:#ffc90e;fill-opacity:1;" />
+   <text style="font-size:24px;" x="140" y="170">C</text>   
+   <path d="M 396,193 74,229" style="fill:none;stroke:#000000;stroke-width:3;marker-start:url(#m1)" />
+   <text x="390" y="213">x</text>
+   <path d="M 64,68 75,230" style="fill:none;stroke:#000000;stroke-width:3;marker-start:url(#m1)" />
+   <text x="45" y="88">y</text>
+   <path d="M 189,152 75,230" style="fill:none;stroke:#000000;stroke-width:3;marker-start:url(#m1)" />
+   <text x="179" y="172">z</text>
+   <path d="m 24,174 0,28 2,0 0,-2 2,0 0,-2 2,0 0,-2 2,0 0,2 2,0 0,4 2,0 0,4 4,0 0,-4 -2,0 0,-4 -2,0 0,-4 8,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 z" style="fill:#808080;fill-opacity:1;stroke:none" />
+   <path d="M 26,171 c 29.2439,-38.65571 82.12691,-77.34202 152.40746,-83.72862" style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:2, 4;marker-end:url(#m2)" />
+   <path d="m 184,88 0,28 2,0 0,-2 2,0 0,-2 2,0 0,-2 2,0 0,2 2,0 0,4 2,0 0,4 4,0 0,-4 -2,0 0,-4 -2,0 0,-4 8,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 -2,0 0,-2 z" style="fill:#000000;fill-opacity:1;stroke:none" />
   </g>
 </svg>

--- a/index.html
+++ b/index.html
@@ -4276,6 +4276,8 @@ window.addEventListener("pointermove", function(event) {
                 </dd>
             <dt><dfn>hit test</dfn></dt>
                 <dd>The process by which the user agent determines a target element for a pointer event. Typically, this is determined by considering the pointer's location and also the visual layout of elements in a document on screen media.</dd>
+            <dt><dfn>hysteresis</dfn></dt>
+            <dd>A feature of human interface design to accept input values within a certain	range of location or time, in order to improve the user experience.  For example, allowing for small deviation in the time it takes for a user to double-click a mouse button is temporal hysteresis, and not immediately closing a nested menu if the user mouses out from the parent window when transitioning to the child menu is locative hysteresis.</dd>
             <dt><dfn data-lt="measurable property">measurable properties</dfn></dt>
                 <dd><p>Measurable properties represent values relating to continuous pointer sensor data that is expressed using a real number or an
                     integer from a large domain. For pointer events, <code>width</code>, <code>height</code>, <code>pressure</code>,

--- a/index.html
+++ b/index.html
@@ -729,6 +729,170 @@ function tilt2spherical(tiltX, tiltY) {
         </section>
 
         <section>
+	        <h3>PointerEvent Algorithms</h3>
+		    <section>
+		        <h4>initialize a {{PointerEvent}}</h4>
+                <p>
+                    To <dfn class="export">initialize a PointerEvent</dfn> with |event|, |eventType| and |eventTarget|, |bubbles|, and |cancelable|, run the following steps:
+                </p>
+                <ol  class="algorithm">
+		            <li>[=Initialize a MouseEvent=] with |event|, |eventType| and |eventTarget|, |bubbles| and |cancelable|</li>
+                    <li>Initialize all other attributes to default {{PointerEvent}} values.</li>
+                </ol>
+		    </section>
+	        <section>
+		        <h4>create a {{PointerEvent}}</h4>
+                <p>
+                    To <dfn class="export"
+                    data-lt="creating a PointerEvent
+                    |created a PointerEvent">create a {{PointerEvent}}</dfn> with |eventType| and |eventTarget|, |bubbles|, and |cancelable|, run the following steps:
+                </p>
+			    <ol class="algorithm">
+			        <li>Let |event| be the result of
+                        [=creating an event=] using {{PointerEvent}}</li>
+			        <li>[=Initialize a PointerEvent=] with |event|, |eventType| and |eventTarget|, |bubbles| and |cancelable|</li>
+			        <li>Return |event|</li>
+              </ol>
+		    </section>
+		    <section>
+		        <h4><dfn class="export"
+                    data-lt="creating PointerEvent from MouseEvent
+                            |created PointerEvent from MouseEvent"
+                    >create {{PointerEvent}} from {{MouseEvent}}</dfn></h4>
+			    <ol class="algorithm">
+			        <li>Let |eventType|, a {{DOMString}} containing the event type</li>
+			        <li>Let |mouseevent|, the corresponding {{MouseEvent}}</li>
+			        <li>Let |event| be the result of
+				        [=creating an event=] using {{PointerEvent}}</li>
+			        <li>Let |target| be the |mouseevent|.{{Event/target}}</li>
+			        <li>[=Initialize a PointerEvent=] with |event|, |eventType| and |target|</li>
+			        <li>Copy {{MouseEvent}} attributes from |mouseevent| into |event|</li>
+			        <li>Return |event|</li>
+                </ol>
+            </section>
+		    <section>
+		        <h4><dfn class="export">maybe send pointerout event</dfn></h4>
+			    <ol class="algorithm">
+			        <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
+			        <li>Set pointerevent attributes
+				<p class="ednote">TODO.</p></li>
+			        <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+			        <li>[=dispatch=] |pointerout| at |target|</li>
+		        </ol>
+            </section>
+		    <section>
+		        <h4><dfn class="export">maybe send pointerleave event</dfn></h4>
+			    <ol class="algorithm">
+                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
+			        <li>Set pointerevent attributes
+				<p class="ednote">TODO.</p></li>
+			        <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+			        <li>[=dispatch=] |pointerout| at |target|</li>
+		        </ol>
+            </section>
+		    <section>
+		        <h4><dfn class="export">maybe send pointerover event</dfn></h4>
+			    <ol class="algorithm">
+                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
+			        <li>Set pointerevent attributes
+				<p class="ednote">TODO.</p></li>
+			        <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+			        <li>[=dispatch=] |pointerout| at |target|</li>
+                </ol>
+		    </section>
+		    <section>
+		        <h4><dfn class="export">maybe send pointerenter event</dfn></h4>
+
+			    <ol class="algorithm">
+                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
+			        <li>Set pointerevent attributes
+                <p class="ednote">TODO.</p></li>
+                    <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+                    <li>[=dispatch=] |pointerout| at |target|</li>
+                </ol>
+		    </section>
+		    <section>
+		        <h4><dfn class="export">maybe send pointermove event</dfn></h4>
+
+			    <ol class="algorithm">
+                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+			<p class="ednote">
+			Can this send pointermove and pointerrawupdate? Or do we need 2 methods?
+			</p>
+			<p class="ednote">
+			What is needed to properly define how pointermove events are coalesced?
+			</p>
+                    </li>
+			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
+			        <li>Set pointerevent attributes
+
+				<p class="ednote">TODO.</p>
+                    </li>
+			        <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+			        <li>[=dispatch=] |pointerout| at |target|</li>
+                </ol>
+		    </section>
+
+		    <section>
+		        <h4><dfn class="export">maybe send pointerdown event</dfn></h4>
+
+			    <ol class="algorithm">
+                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+			<p class="note">
+			Unlike mousedown events,
+			<a href="https://w3c.github.io/pointerevents/#the-pointerdown-event">pointerdown</a>
+			events are not nested when multiple buttons are pressed.
+			The MouseEvent is passed so that the fields can be copied into the PointerEvent.
+			</p>
+                    </li>
+			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|
+			        <li>Set pointerevent attributes
+				<p class="ednote">TODO.</p>
+                    </li>
+                    <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+                    <li>[=dispatch=] |pointerout| at |target|</li>
+                </ol>
+            </section>
+
+            <section>
+                <h4><dfn class="export">maybe send pointerrawupdate event</dfn></h4>
+
+                <ol class="algorithm">
+                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+			        <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+			        <li>[=dispatch=] |pointerout| at |target|</li>
+                </ol>
+            </section>
+
+		    <section>
+		        <h4><dfn class="export">maybe send pointerup event</dfn></h4>
+
+			    <ol class="algorithm">
+                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+
+
+			<p class="ednote">
+			Unlike mouseup events, {{GlobalEventHandlers/pointerup}} events are not nested when multiple buttons are pressed. The MouseEvent is passed so that the fields can be copied into the PointerEvent.
+			</p>
+                    </li>
+			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|
+			        <li>Set pointerevent attributes
+				<p class="ednote">
+				TODO.
+				</p>
+                    </li>
+			        <li>Let |target| be the |mouseout|.{{Event/target}}</li>
+			        <li>[=dispatch=] |pointerout| at |target|</li>
+                </ol>
+		    </section>
+
+        </section>
+
+        <section>
             <h2><dfn>Pointer Event types</dfn></h2>
             <p>Below are the event types defined in this specification.</p>
             <p>In the case of the <a>primary pointer</a>, these events (with the exception of {{GlobalEventHandlers/gotpointercapture}} and {{GlobalEventHandlers/lostpointercapture}}) may also fire <a>compatibility mouse events</a>.</p>

--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@ interface MouseEvent : UIEvent {
                     </p>
 				</dd>
 
-				<dt><dfn method>getModifierState(keyArg)</dfn></dt>
+				<dt><dfn>getModifierState(keyArg)</dfn></dt>
 				<dd>
                     <p>
 					    Queries the state of a modifier using a key value.
@@ -600,7 +600,7 @@ dictionary MouseEventInit : EventModifierInit {
 	EventTarget? relatedTarget = null;
 };
             </pre>
-			<dl dfn-for="MouseEventInit">
+			<dl data-dfn-for="MouseEventInit">
 				<dt><dfn>screenX</dfn></dt>
 				<dd>
 					<p>
@@ -672,7 +672,7 @@ dictionary MouseEventInit : EventModifierInit {
 				<dt><dfn>relatedTarget</dfn></dt>
 				<dd>
 					<p>
-                        The {{relatedTarget}} should be initialized to the element whose bounds the mouse pointer just left (in the case of a [=mouseover=] or [=mouseenter=] event) or the element whose bounds the mouse pointer is entering (in the case of a [=mouseout=] or [=mouseleave=] or [=focusout=] event). For other events, this value need not be assigned (and will default to null).
+                        The {{MouseEvent/relatedTarget}} should be initialized to the element whose bounds the mouse pointer just left (in the case of a [=mouseover=] or [=mouseenter=] event) or the element whose bounds the mouse pointer is entering (in the case of a [=mouseout=] or [=mouseleave=] or [=focusout=] event). For other events, this value need not be assigned (and will default to null).
 					</p>
 				</dd>
 			</dl>
@@ -1263,11 +1263,11 @@ dictionary MouseEventInit : EventModifierInit {
 				<li>Let |result| be <a>dispatch</a> |menuevent| at |target|</li>
 				<li>If |result| is true, then show the UA context menu</li>
                 </ol>
+            </li>
+            </ol>
 			<p class="note">
 			To handle a context menu triggered by the keyboard, call this algorithm with |native| = null and |target| = currently focused element.
 			</p>
-            </li>
-            </ol>
 		
 
 
@@ -1853,8 +1853,7 @@ myDiv.addEventListener("auxclick", function(e) {
 
 	<table class="event-definition">
     <tbody>
-      <tr>
-        <tr><th>Type</th>
+      <tr><th>Type</th>
 	    <td><strong><code>contextmenu</code></strong></td>
 		<tr><th>Interface</th>
 		<td>{{PointerEvent}}</td>
@@ -3460,14 +3459,14 @@ function tilt2spherical(tiltX, tiltY) {
 			};
 			</pre>
 
-			<dl dfn-for="WheelEventInit">
-				<dt><dfn dict-member>deltaX</dfn></dt>
+			<dl data-dfn-for="WheelEventInit">
+				<dt><dfn>deltaX</dfn></dt>
 				<dd>See <code>deltaZ</code> attribute.</dd>
 
-				<dt><dfn dict-member>deltaY</dfn></dt>
+				<dt><dfn>deltaY</dfn></dt>
 				<dd>See <code>deltaZ</code> attribute.</dd>
 
-				<dt><dfn dict-member>deltaZ</dfn></dt>
+				<dt><dfn>deltaZ</dfn></dt>
 				<dd>
 					Initializes the {{WheelEvent/deltaZ}} attribute of the {{WheelEvent}}
 					object. Relative positive values for this attribute (as well as
@@ -3479,7 +3478,7 @@ function tilt2spherical(tiltX, tiltY) {
 					opposite directions.
 				</dd>
 
-				<dt><dfn dict-member>deltaMode</dfn></dt>
+				<dt><dfn>deltaMode</dfn></dt>
 				<dd>
 					Initializes the {{WheelEvent/deltaMode}} attribute on the
 					{{WheelEvent}} object to the enumerated values 0, 1, or 2, which
@@ -4337,7 +4336,7 @@ window.addEventListener("pointermove", function(event) {
             <dt><dfn>contact geometry</dfn></dt>
                 <dd>The bounding box of an input (most commonly, touch) on a digitizer. This typically refers to devices with coarser pointer input resolution than a single pixel. Some devices do not report this data at all.</dd>
             <dt><dfn>delta</dfn></dt>
-                <dd>The estimated scroll amount (in pixels, lines, or pages) that the user agent will scroll or zoom the page in response to the physical movement of an input device that supports the {{WheelEvent}} interface (such as a mouse wheel or touch pad). The value of a <a>delta</a> (e.g., the {{WheelEvent/deltaX}}, {{WheelEvent/deltaY}}, or {{WheelEvent/deltaZ}} attributes) is to be interpreted in the context of the current {{WheelEvent/deltaMode}} property. The relationship between the physical movement of a wheel (or other device) and whether the <a>delta</a> is positive or negative is environment and device dependent. However, if a user agent scrolls as the <a>default action</a> then the sign of the <a>delta</a> is given by a right-hand coordinate system where positive X,Y, and Z axes are directed towards the right-most edge, bottom-most edge, and farthest depth (away from the user) of the <a for=/>document</a>, respectively.</dd>
+                <dd>The estimated scroll amount (in pixels, lines, or pages) that the user agent will scroll or zoom the page in response to the physical movement of an input device that supports the {{WheelEvent}} interface (such as a mouse wheel or touch pad). The value of a <a>delta</a> (e.g., the {{WheelEvent/deltaX}}, {{WheelEvent/deltaY}}, or {{WheelEvent/deltaZ}} attributes) is to be interpreted in the context of the current {{WheelEvent/deltaMode}} property. The relationship between the physical movement of a wheel (or other device) and whether the <a>delta</a> is positive or negative is environment and device dependent. However, if a user agent scrolls as the <a>default action</a> then the sign of the <a>delta</a> is given by a right-hand coordinate system where positive X,Y, and Z axes are directed towards the right-most edge, bottom-most edge, and farthest depth (away from the user) of the [=document=], respectively.</dd>
 
             <dt><dfn>digitizer</dfn></dt>
                 <dd>A type of input sensing device in which a surface can detect input which is in contact and/or in close proximity. Most commonly, this is the surface that senses input from the touch contact or a pen/stylus.</dd>
@@ -4402,7 +4401,7 @@ The following features are obsolete and should only be implemented by
 		</pre>
 
 		<dl data-dfn-for="MouseEvent">
-			<dt><dfn method>initMouseEvent(typeArg)</dfn></dt>
+			<dt><dfn>initMouseEvent(typeArg)</dfn></dt>
 			<dd>
 				Initializes attributes of a {{MouseEvent}} object. This
 				method has the same behavior as <code>UIEvent.initUIEvent()</code>.

--- a/index.html
+++ b/index.html
@@ -2599,7 +2599,7 @@ interface PointerEvent : MouseEvent {
                 <p><dfn>Determine the target</dfn> at which the event is fired as follows:</p>
                 <ul>
                     <li>If the <a>pointer capture target override</a> has been set for the pointer, set the target to <a>pointer capture target override</a> object.</li>
-                    <li>Otherwise, set the target to the object returned by normal <a>hit test</a> mechanisms (out of scope for this specification).</li>
+                    <li>Otherwise, set the target to the object returned by <a>hit test</a>.</li>
                 </ul>
 
                 <p>Let |targetDocument| be target's [=Node/node document=] [[DOM]].</p>

--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@ interface MouseEvent : UIEvent {
 					    The value of {{MouseEvent/button}} is not updated for events not caused by the depression/release of a mouse button. In these scenarios, take care not to interpret the value <code>0</code> as the left button, but rather as the default value.
 					</p>
 					<p class="note">
-					    Some <a>default actions</a> related to events such as [=mousedown=] and [=mouseup=] depend on the specific mouse button in use.
+					    Some <a>default actions</a> related to events such as {{mousedown}} and {{mouseup}} depend on the specific mouse button in use.
 					</p>
                     <p>
                         The [=un-initialized value=] of this attribute MUST be <code>0</code>.
@@ -532,7 +532,7 @@ interface MouseEvent : UIEvent {
                         During any mouse events, {{MouseEvent/buttons}} MUST be used to indicate which combination of mouse buttons are currently being pressed, expressed as a bitmask.
                     </p>
 					<p class="note">
-					    Though similarly named, the values for the {{MouseEvent/buttons}} attribute and the {{MouseEvent/button}} attribute are very different. The value of {{MouseEvent/button}} is assumed to be valid during [=mousedown=] / [=mouseup=] event handlers, whereas the {{MouseEvent/buttons}} attribute reflects the state of the mouse's buttons for any trusted {{MouseEvent}} object (while it is being dispatched), because it can represent the "no button currently active" state (0).
+					    Though similarly named, the values for the {{MouseEvent/buttons}} attribute and the {{MouseEvent/button}} attribute are very different. The value of {{MouseEvent/button}} is assumed to be valid during {{mousedown}} / {{mouseup}} event handlers, whereas the {{MouseEvent/buttons}} attribute reflects the state of the mouse's buttons for any trusted {{MouseEvent}} object (while it is being dispatched), because it can represent the "no button currently active" state (0).
 					</p>
 
 					<p>
@@ -552,7 +552,7 @@ interface MouseEvent : UIEvent {
 					    Because the sum of any set of button values is a unique number, a content author can use a bitwise operation to determine how many buttons are currently being pressed and which buttons they are, for an arbitrary number of mouse buttons on a device. For example, the value <code>3</code> indicates that the left and right button are currently both pressed, while the value <code>5</code> indicates that the left and middle button are currently both pressed.
                     </p>
 					<p class="note">
-					    Some <a>default actions</a> related to events such as [=mousedown=] and [=mouseup=] depend on the specific mouse button in use.
+					    Some <a>default actions</a> related to events such as {{mousedown}} and {{mouseup}} depend on the specific mouse button in use.
 					</p>
                     <p>
                         The [=un-initialized value=] of this attribute MUST be <code>0</code>.
@@ -672,7 +672,7 @@ dictionary MouseEventInit : EventModifierInit {
 				<dt><dfn>relatedTarget</dfn></dt>
 				<dd>
 					<p>
-                        The {{MouseEvent/relatedTarget}} should be initialized to the element whose bounds the mouse pointer just left (in the case of a [=mouseover=] or [=mouseenter=] event) or the element whose bounds the mouse pointer is entering (in the case of a [=mouseout=] or [=mouseleave=] or [=focusout=] event). For other events, this value need not be assigned (and will default to null).
+                        The {{MouseEvent/relatedTarget}} should be initialized to the element whose bounds the mouse pointer just left (in the case of a {{mouseover}} or {{mouseenter}} event) or the element whose bounds the mouse pointer is entering (in the case of a {{mouseout}} or {{mouseleave}} or [=focusout=] event). For other events, this value need not be assigned (and will default to null).
 					</p>
 				</dd>
 			</dl>
@@ -1287,7 +1287,7 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td style="text-align:center">
        <td>
       <tr>
@@ -1297,19 +1297,19 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into element A...</em>
       <tr>
        <td class="cell-number">2
-       <td>[=mouseover=]
+       <td>{{mouseover}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">3
-       <td>[=mouseenter=]
+       <td>{{mouseenter}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">4
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td style="text-align:center">A
-       <td>Multiple [=mousemove=] events
+       <td>Multiple {{mousemove}} events
       <tr>
        <td class="cell-number">
        <td>
@@ -1317,12 +1317,12 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved out of element A...</em>
       <tr>
        <td class="cell-number">5
-       <td>[=mouseout=]
+       <td>{{mouseout}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">6
-       <td>[=mouseleave=]
+       <td>{{mouseleave}}
        <td style="text-align:center">A
        <td>
     </table>
@@ -1340,7 +1340,7 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>[=mousemove=]</a>
+       <td>{{mousemove}}</a>
        <td style="text-align:center">
        <td>
       <tr>
@@ -1350,19 +1350,19 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into element A...</em>
       <tr>
        <td class="cell-number">2
-       <td>[=mouseover=]
+       <td>{{mouseover}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">3
-       <td>[=mouseenter=]
+       <td>{{mouseenter}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">4
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td style="text-align:center">A
-       <td>Multiple [=mousemove=] events
+       <td>Multiple {{mousemove}} events
       <tr>
        <td class="cell-number">
        <td>
@@ -1370,24 +1370,24 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into nested element B...</em>
       <tr>
        <td class="cell-number">5
-       <td>[=mouseout=]
+       <td>{{mouseout}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">6
-       <td>[=mouseover=]
+       <td>{{mouseover}}
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">7
-       <td>[=mouseenter=]
+       <td>{{mouseenter}}
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">8
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td style="text-align:center">B
-       <td>Multiple [=mousemove=] events
+       <td>Multiple {{mousemove}} events
       <tr>
        <td class="cell-number">
        <td>
@@ -1395,24 +1395,24 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved from element B into A...</em>
       <tr>
        <td class="cell-number">9
-       <td>[=mouseout=]
+       <td>{{mouseout}}
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">10
-       <td>[=mouseleave=]
+       <td>{{mouseleave}}
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">11
-       <td>[=mouseover=]
+       <td>{{mouseover}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">12
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td style="text-align:center">A
-       <td>Multiple [=mousemove=] events
+       <td>Multiple {{mousemove}} events
       <tr>
        <td class="cell-number">
        <td>
@@ -1420,12 +1420,12 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved out of element A...</em>
       <tr>
        <td class="cell-number">13
-       <td>[=mouseout=]
+       <td>{{mouseout}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">14
-       <td>[=mouseleave=]
+       <td>{{mouseleave}}
        <td style="text-align:center">A
        <td>
     </table>
@@ -1452,7 +1452,7 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td style="text-align:center">
        <td>
       <tr>
@@ -1462,29 +1462,29 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into element C, the topmost element in the stack</em>
       <tr>
        <td class="cell-number">2
-       <td>[=mouseover=]
+       <td>{{mouseover}}
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">3
-       <td>[=mouseenter=]
+       <td>{{mouseenter}}
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">4
-       <td>[=mouseenter=]
+       <td>{{mouseenter}}
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">5
-       <td>[=mouseenter=]
+       <td>{{mouseenter}}
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">6
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td style="text-align:center">C
-       <td>Multiple [=mousemove=] events
+       <td>Multiple {{mousemove}} events
       <tr>
        <td class="cell-number">
        <td>
@@ -1492,28 +1492,28 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved out of element C...</em>
       <tr>
        <td class="cell-number">7
-       <td>[=mouseout=]
+       <td>{{mouseout}}
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">8
-       <td>[=mouseleave=]
+       <td>{{mouseleave}}
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">9
-       <td>[=mouseleave=]
+       <td>{{mouseleave}}
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">10
-       <td>[=mouseleave=]
+       <td>{{mouseleave}}
        <td style="text-align:center">A
        <td>
     </table>
 
 		<p class="note">
-		    The [=mouseover=]/[=mouseout=] events are only fired once, while [=mouseenter=]/[=mouseleave=] events are fired three times (once to each element).
+		    The {{mouseover}}/{{mouseout}} events are only fired once, while {{mouseenter}}/{{mouseleave}} events are fired three times (once to each element).
 		</p>
 
 		<p>
@@ -1529,65 +1529,65 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>[=mousedown=]
+       <td>{{mousedown}}
        <td>
       <tr>
        <td class="cell-number">2
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td>OPTIONAL, multiple events, some limits
       <tr>
        <td class="cell-number">3
-       <td>[=mouseup=]
+       <td>{{mouseup}}
        <td>
       <tr>
        <td class="cell-number">4
-       <td>[=click=]
+       <td>{{click}}
        <td>
       <tr>
        <td class="cell-number">5
-       <td>[=mousemove=]
+       <td>{{mousemove}}
        <td>OPTIONAL, multiple events, some limits
       <tr>
        <td class="cell-number">6
-       <td>[=mousedown=]
+       <td>{{mousedown}}
        <td>
       <tr>
        <td class="cell-number">7
-       <td>[=mousemove=]</a>
+       <td>{{mousemove}}</a>
        <td>OPTIONAL, multiple events, some limits
       <tr>
        <td class="cell-number">8
-       <td>[=mouseup=]</a>
+       <td>{{mouseup}}</a>
        <td>
       <tr>
        <td class="cell-number">9
-       <td>[=click=]
+       <td>{{click}}
        <td>
       <tr>
        <td class="cell-number">10
-       <td>[=dblclick=]
+       <td>{{dblclick}}
        <td>
     </table>
 
 		<p class="note">
-		The lag time, degree, distance, and number of [=mousemove=] events allowed between the [=mousedown=] and [=mouseup=] events while still firing a [=click=] or [=dblclick=] event will be implementation-, device-, and platform-specific. This tolerance can aid users that have physical disabilities like unsteady hands when these users interact with a pointing device.
+		The lag time, degree, distance, and number of {{mousemove}} events allowed between the {{mousedown}} and {{mouseup}} events while still firing a {{click}} or {{dblclick}} event will be implementation-, device-, and platform-specific. This tolerance can aid users that have physical disabilities like unsteady hands when these users interact with a pointing device.
 		</p>
 
 		<p>
             Each implementation will determine the appropriate <a>hysteresis</a>
-		tolerance, but in general SHOULD fire [=click=] and [=dblclick=]
-		events when the event target of the associated [=mousedown=] and
-		[=mouseup=] events is the same element with no [=mouseout=] or
-		[=mouseleave=] events intervening, and SHOULD fire [=click=] and
-		[=dblclick=] events on the nearest common inclusive ancestor when the
-		associated [=mousedown=] and [=mouseup=] event targets are
+		tolerance, but in general SHOULD fire {{click}} and {{dblclick}}
+		events when the event target of the associated {{mousedown}} and
+		{{mouseup}} events is the same element with no {{mouseout}} or
+		{{mouseleave}} events intervening, and SHOULD fire {{click}} and
+		{{dblclick}} events on the nearest common inclusive ancestor when the
+		associated {{mousedown}} and {{mouseup}} event targets are
 		different.
         </p>
 
 		<p class="example">
-		If a [=mousedown=] event was targeted at an HTML document's <a data-lt="the body element">body
-		element</a>, and the corresponding [=mouseup=] event was targeted at
-		the <a>document element</a>, then the [=click=] event will be dispatched
+		If a {{mousedown}} event was targeted at an HTML document's <a data-lt="the body element">body
+		element</a>, and the corresponding {{mouseup}} event was targeted at
+		the <a>document element</a>, then the {{click}} event will be dispatched
 		to the <a>document element</a>, since it is the nearest common inclusive
 		ancestor.
 		</p>
@@ -1598,13 +1598,13 @@ dictionary MouseEventInit : EventModifierInit {
 
 		<p class="example">
 		If the target element is removed from the DOM as the result of a
-		[=mousedown=] event, no events for that element will be dispatched
-		for [=mouseup=], [=click=], or [=dblclick=], nor any default
-		activation events. However, the [=mouseup=] event will still be
+		{{mousedown}} event, no events for that element will be dispatched
+		for {{mouseup}}, {{click}}, or {{dblclick}}, nor any default
+		activation events. However, the {{mouseup}} event will still be
 		dispatched on the element that is exposed to the mouse after the removal
 		of the initial target element. Similarly, if the target element is
-		removed from the DOM during the dispatch of a [=mouseup=] event, the
-		[=click=] and subsequent events will not be dispatched.
+		removed from the DOM during the dispatch of a {{mouseup}} event, the
+		{{click}} and subsequent events will not be dispatched.
 		</p>
 
 	<h4>Mouse Event Types</h4>
@@ -1614,7 +1614,7 @@ dictionary MouseEventInit : EventModifierInit {
 		Ancestors of the targeted element MAY use bubbling to obtain
 		notification of mouse events which occur within its descendent elements.
 
-	<h5><dfn>auxclick</dfn></h5>
+	<h5><dfn class="export" data-dfn-type="event">auxclick</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -1660,7 +1660,7 @@ dictionary MouseEventInit : EventModifierInit {
         </ul>
     </table>
             <p>
-			The [=auxclick=] event type MUST be dispatched on the <a>topmost
+			The {{auxclick}} event type MUST be dispatched on the <a>topmost
 			event target</a> indicated by the pointer, when the user presses
 			down and releases the non-primary pointer button, or otherwise activates
 			the pointer in a manner that simulates such an action. The actuation
@@ -1670,27 +1670,27 @@ dictionary MouseEventInit : EventModifierInit {
 			device button.
 
 			<p>
-            The [=auxclick=] event should only be fired for the non-primary pointer
+            The {{auxclick}} event should only be fired for the non-primary pointer
 			buttons (i.e., when {{MouseEvent/button}} value is not <code>0</code>,
 			{{MouseEvent/buttons}} value is greater than <code>1</code>). The primary button
 			(like the left button on a standard mouse) MUST NOT fire
-			[=auxclick=] events. See [=click=] for a corresponding event that
+			{{auxclick}} events. See {{click}} for a corresponding event that
 			is associated with the primary button.
 
 			<p>
-            The [=auxclick=] event MAY be preceded by the [=mousedown=] and
-			[=mouseup=] events on the same element, disregarding changes
+            The {{auxclick}} event MAY be preceded by the {{mousedown}} and
+			{{mouseup}} events on the same element, disregarding changes
 			between other node types (e.g., text nodes).  Depending upon the
-			environment configuration, the [=auxclick=] event MAY be dispatched
-			if one or more of the event types [=mouseover=],
-			[=mousemove=], and [=mouseout=] occur between the press and
+			environment configuration, the {{auxclick}} event MAY be dispatched
+			if one or more of the event types {{mouseover}},
+			{{mousemove}}, and {{mouseout}} occur between the press and
 			release of the pointing device button.
 
 			<p>
-            The <a>default action</a> of the [=auxclick=] event type varies
+            The <a>default action</a> of the {{auxclick}} event type varies
 			based on the [=Event/target=] of the event and the value of the
 			{{MouseEvent/button}} or {{MouseEvent/buttons}} attributes. Typical
-			<a>default actions</a> of the [=auxclick=] event type are as follows:
+			<a>default actions</a> of the {{auxclick}} event type are as follows:
 
 			<ul><li>
                 If the [=Event/target=] has associated activation behavior,
@@ -1711,8 +1711,8 @@ dictionary MouseEventInit : EventModifierInit {
 });
 </code></pre>
 			<p class="note">
-			In the case of right button, the [=auxclick=] event is dispatched after
-			any [=contextmenu=] event. Note that some user agents swallow all input
+			In the case of right button, the {{auxclick}} event is dispatched after
+			any {{contextmenu}} event. Note that some user agents swallow all input
 			events while a context menu is being displayed, so auxclick may not be
 			available to applications in such scenarios.
 			See <a href="#example-auxclick-right"></a> for more clarification.
@@ -1732,7 +1732,7 @@ myDiv.addEventListener("auxclick", function(e) {
 });
 </code></pre>
 
-		<h5><dfn>click</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">click</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -1778,7 +1778,7 @@ myDiv.addEventListener("auxclick", function(e) {
         </ul>
     </table>
             <p>
-			The [=click=] event type MUST be dispatched on the <a>topmost
+			The {{click}} event type MUST be dispatched on the <a>topmost
 			event target</a> indicated by the pointer, when the user presses
 			down and releases the primary pointer button, or otherwise activates
 			the pointer in a manner that simulates such an action. The actuation
@@ -1788,22 +1788,22 @@ myDiv.addEventListener("auxclick", function(e) {
 			device button.
 
 			<p>
-			The [=click=] event should only be fired for the primary pointer
+			The {{click}} event should only be fired for the primary pointer
 			button (i.e., when {{MouseEvent/button}} value is <code>0</code>,
 			{{MouseEvent/buttons}} value is <code>1</code>). Secondary buttons
 			(like the middle or right button on a standard mouse) MUST NOT fire
-			[=click=] events. See [=auxclick=] for a corresponding event that
+			{{click}} events. See {{auxclick}} for a corresponding event that
 			is associated with the non-primary buttons.
 
 			<p>
-			The [=click=] event MAY be preceded by the [=mousedown=] and
-			[=mouseup=] events on the same element, disregarding changes
+			The {{click}} event MAY be preceded by the {{mousedown}} and
+			{{mouseup}} events on the same element, disregarding changes
 			between other node types (e.g., text nodes).  Depending upon the
-			environment configuration, the [=click=] event MAY be dispatched
-			if one or more of the event types [=mouseover=],
-			[=mousemove=], and [=mouseout=] occur between the press and
-			release of the pointing device button.  The [=click=] event MAY
-			also be followed by the [=dblclick=] event.
+			environment configuration, the {{click}} event MAY be dispatched
+			if one or more of the event types {{mouseover}},
+			{{mousemove}}, and {{mouseout}} occur between the press and
+			release of the pointing device button.  The {{click}} event MAY
+			also be followed by the {{dblclick}} event.
 
 			<p class="example">
 			If a user mouses down on a text node child of a
@@ -1813,33 +1813,33 @@ myDiv.addEventListener("auxclick", function(e) {
 			block of that <code>&lt;p&gt;</code> element (i.e., the pointer is
 			between lines of the same text block, but not over the text node per
 			se), then subsequently mouses up, this will likely still trigger a
-			[=click=] event (if it falls within the normal temporal
-			<a>hysteresis</a> for a [=click=]), since the user has stayed
+			{{click}} event (if it falls within the normal temporal
+			<a>hysteresis</a> for a {{click}}), since the user has stayed
 			within the scope of the same element. Note that user-agent-generated
 			mouse events are not dispatched on text nodes.
 			</p>
 
 			<p>
 			In addition to being associated with pointer devices, the
-			[=click=] event type MUST be dispatched as part of an element
+			{{click}} event type MUST be dispatched as part of an element
 			activation.
 
 			<p class="note">
 			For maximum accessibility, content authors are encouraged to use the
-			[=click=] event type when defining activation behavior for custom
+			{{click}} event type when defining activation behavior for custom
 			controls, rather than other pointing-device event types such as
-			[=mousedown=] or [=mouseup=], which are more device-specific.
-			Though the [=click=] event type has its origins in pointer
+			{{mousedown}} or {{mouseup}}, which are more device-specific.
+			Though the {{click}} event type has its origins in pointer
 			devices (e.g., a mouse), subsequent implementation enhancements have
 			extended it beyond that association, and it can be considered a
 			device-independent event type for element activation.
 			</p>
 
 			<p>
-			The <a>default action</a> of the [=click=] event type varies
+			The <a>default action</a> of the {{click}} event type varies
 			based on the [=Event/target=] of the event and the value of the
 			{{MouseEvent/button}} or {{MouseEvent/buttons}} attributes. Typical
-			<a>default actions</a> of the [=click=] event type are as follows:
+			<a>default actions</a> of the {{click}} event type are as follows:
 
 		    <ul>
 				<li>If the [=Event/target=] has associated activation behavior,
@@ -1849,7 +1849,7 @@ myDiv.addEventListener("auxclick", function(e) {
 				action</a> MUST be to give that element document focus.</li>
 			</ul>
 
-		<h5><dfn>contextmenu</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">contextmenu</dfn></h5>
 
 	<table class="event-definition">
     <tbody>
@@ -1895,14 +1895,14 @@ myDiv.addEventListener("auxclick", function(e) {
 
 			<p>
 			When the {{contextmenu}} event is triggered by right mouse button, the
-			{{contextmenu}} event MUST be dispatched after the [=mousedown=] event.
+			{{contextmenu}} event MUST be dispatched after the {{mousedown}} event.
 
 			<p class="note">
 			Depending on the platform, the {{contextmenu}} event may be dispatched
-			before or after the [=mouseup=] event.
+			before or after the {{mouseup}} event.
 			</p>
 
-		<h5><dfn>dblclick</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">dblclick</dfn></h5>
 
 <table class="event-definition">
     <tbody>
@@ -1958,28 +1958,28 @@ myDiv.addEventListener("auxclick", function(e) {
 			of a pointing device is clicked twice over an element. The
 			definition of a double click depends on the environment
 			configuration, except that the event target MUST be the same between
-			[=mousedown=], [=mouseup=], and [=dblclick=]. This event
-			type MUST be dispatched after the event type [=click=] if a click
+			{{mousedown}}, {{mouseup}}, and {{dblclick}}. This event
+			type MUST be dispatched after the event type {{click}} if a click
 			and double click occur simultaneously, and after the event type
-			[=mouseup=] otherwise.
+			{{mouseup}} otherwise.
 
 			<p>
-			As with the [=click=] event, the [=dblclick=] event should
+			As with the {{click}} event, the {{dblclick}} event should
 			only be fired for the primary pointer button. Secondary buttons MUST
-			NOT fire [=dblclick=] events.
+			NOT fire {{dblclick}} events.
 
 			<p class="note">
-			Canceling the [=click=] event does not affect the firing of a
-			[=dblclick=] event.
+			Canceling the {{click}} event does not affect the firing of a
+			{{dblclick}} event.
 			</p>
 
-			As with the [=click=] event type, the <a>default action</a> of
-			the [=dblclick=] event type varies based on the [=Event/target=] of the event and the value of the {{MouseEvent/button}}
+			As with the {{click}} event type, the <a>default action</a> of
+			the {{dblclick}} event type varies based on the [=Event/target=] of the event and the value of the {{MouseEvent/button}}
 			or {{MouseEvent/buttons}} attributes. The typical
-			<a>default actions</a> of the [=dblclick=] event type match those
-			of the [=click=] event type.
+			<a>default actions</a> of the {{dblclick}} event type match those
+			of the {{click}} event type.
 
-		<h5><dfn>mousedown</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">mousedown</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -2008,7 +2008,7 @@ myDiv.addEventListener("auxclick", function(e) {
 			<ul>
 <li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
 <li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
-<li>{{UIEvent}}.{{UIEvent/detail}} : indicates the <a href="#current-click-count">current click count</a> incremented by one. For example, if no click happened before the [=mousedown=], {{UIEvent/detail}} will contain the value <code>1</code></li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : indicates the <a href="#current-click-count">current click count</a> incremented by one. For example, if no click happened before the {{mousedown}}, {{UIEvent/detail}} will contain the value <code>1</code></li>
 <li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
 the screen</li>
 <li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
@@ -2034,17 +2034,17 @@ within the containing element</li>
 			button is pressed over an element.
 
 			<p class="note">
-			Many implementations use the [=mousedown=] event to begin a
+			Many implementations use the {{mousedown}} event to begin a
 			variety of contextually dependent <a>default actions</a>. These
 			default actions can be prevented if this event is canceled. Some of
 			these default actions could include: beginning a drag/drop
 			interaction with an image or link, starting text selection, etc.
 			Additionally, some implementations provide a mouse-driven panning
 			feature that is activated when the middle mouse button is pressed at
-			the time the [=mousedown=] event is dispatched.
+			the time the {{mousedown}} event is dispatched.
 			</p>
 
-		<h5><dfn>mouseenter</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">mouseenter</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -2099,7 +2099,7 @@ within the containing element</li>
 			is moved onto the boundaries of an element or one of its descendent
 			elements.  A <a data-cite="infra">user agent</a> MUST also dispatch this event when the
 			element or one of its descendants moves to be underneath the primary
-			pointing device. This event type is similar to [=mouseover=], but
+			pointing device. This event type is similar to {{mouseover}}, but
 			differs in that it does not bubble, and MUST NOT be dispatched when
 			the pointer device moves from an element onto the boundaries of one
 			of its descendent elements.
@@ -2108,10 +2108,10 @@ within the containing element</li>
 			There are similarities between this event type and the CSS
 			<a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes"
 			title="Selectors"><code>:hover</code> pseudo-class</a> [[CSS2]].
-			See also the [=mouseleave=] event type.
+			See also the {{mouseleave}} event type.
 			</p>
 
-		<h5><dfn>mouseleave</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">mouseleave</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -2166,7 +2166,7 @@ within the containing element</li>
 			is moved off of the boundaries of an element and all of its
 			descendent elements.  A <a data-cite="infra">user agent</a> MUST also dispatch this event
 			when the element or one of its descendants moves to be no longer underneath
-			the primary pointing device. This event type is similar to [=mouseout=],
+			the primary pointing device. This event type is similar to {{mouseout}},
 			but differs in that does not bubble, and that it MUST NOT be
 			dispatched until the pointing device has left the boundaries of the
 			element and the boundaries of all of its children.
@@ -2175,10 +2175,10 @@ within the containing element</li>
 			There are similarities between this event type and the CSS
 			<a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes"
 			title="Selectors"><code>:hover</code> pseudo-class</a> [[CSS2]].
-			See also the [=mouseenter=] event type.
+			See also the {{mouseenter}} event type.
 			</p>
 
-		<h5><dfn>mousemove</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">mousemove</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -2231,7 +2231,7 @@ within the containing element</li>
 			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
 			is moved while it is over an element.  The frequency rate of events
 			while the pointing device is moved is implementation-, device-, and
-			platform-specific, but multiple consecutive [=mousemove=] events
+			platform-specific, but multiple consecutive {{mousemove}} events
 			SHOULD be fired for sustained pointer-device movement, rather than a
 			single event for each instance of mouse movement.  Implementations
 			are encouraged to determine the optimal frequency rate to balance
@@ -2239,7 +2239,7 @@ within the containing element</li>
 
 			<p class="note">
 			In some implementation environments, such as a browser,
-			[=mousemove=] events can continue to fire if the user began a
+			{{mousemove}} events can continue to fire if the user began a
 			drag operation (e.g., a mouse button is pressed) and the pointing
 			device has left the boundary of the user agent.
 			</p>
@@ -2250,7 +2250,7 @@ within the containing element</li>
 			user agents.
 			</p>
 
-		<h5><dfn>mouseout</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">mouseout</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -2304,15 +2304,15 @@ within the containing element</li>
 			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
 			is moved off of the boundaries of an element or when the element is
 			moved to be no longer underneath the primary pointing device.
-			This event type is similar to [=mouseleave=], but differs in that
+			This event type is similar to {{mouseleave}}, but differs in that
 			does bubble, and that it MUST be dispatched when the pointer device
 			moves from an element onto the boundaries of one of its descendent elements.
 
 			<p class="note">
-			See also the [=mouseover=] event type.
+			See also the {{mouseover}} event type.
 			</p>
 
-		<h5><dfn>mouseover</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">mouseover</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -2366,15 +2366,15 @@ within the containing element</li>
 			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
 			is moved onto the boundaries of an element or when the element is
 			moved to be underneath the primary pointing device.
-			This event type is similar to [=mouseenter=], but differs in
+			This event type is similar to {{mouseenter}}, but differs in
 			that it bubbles, and that it MUST be dispatched when the pointer device moves onto the
 			boundaries of an element whose ancestor element is the [=Event/target=] for the same <a>event listener</a> instance.
 
 			<p class="note">
-			See also the [=mouseout=] event type.
+			See also the {{mouseout}} event type.
 			</p>
 
-		        <h5><dfn>mouseup</dfn></h5>
+		        <h5><dfn class="export" data-dfn-type="event">mouseup</dfn></h5>
 
 <table class="event-definition">
      <tbody>
@@ -2430,7 +2430,7 @@ within the containing element</li>
 
 			<p class="note">
 			In some implementation environments, such as a browser, a
-			[=mouseup=] event can be dispatched even if the pointing device
+			{{mouseup}} event can be dispatched even if the pointing device
 			has left the boundary of the user agent, e.g., if the user began a
 			drag operation with a mouse button pressed.
 			</p>
@@ -3318,10 +3318,10 @@ function tilt2spherical(tiltX, tiltY) {
 
 	The sign (positive or negative) of the values of the deltaX, deltaY, and deltaZ attributes
 	MUST be consistent between multiple dispatches of the
-	[=wheel=] event while the
+	{{wheel}} event while the
 	motion of the actual wheel device is rotating/moving in the same direction.
 	If a user agent scrolls as the default action of the
-	[=wheel=] event then the sign
+	{{wheel}} event then the sign
 	of the <a>delta</a> SHOULD be given by a right-hand coordinate system where positive X,
 	Y, and Z axes are directed towards the right-most edge, bottom-most edge, and farthest
 	depth (away from the user) of the document, respectively.
@@ -3350,7 +3350,7 @@ function tilt2spherical(tiltX, tiltY) {
 	<h4 id="interface-wheelevent">Interface WheelEvent</h4>
 
 		The {{WheelEvent}} interface provides specific contextual information
-		associated with [=wheel=] events.
+		associated with {{wheel}} events.
 
 		To create an instance of the {{WheelEvent}} interface, use the {{WheelEvent}} constructor,
 		passing an optional {{WheelEventInit}} dictionary.
@@ -3395,7 +3395,7 @@ function tilt2spherical(tiltX, tiltY) {
 
 				<dt><dfn>deltaX</dfn></dt>
 				<dd>
-					In user agents where the default action of the [=wheel=]
+					In user agents where the default action of the {{wheel}}
 					event is to scroll, the value MUST be the measurement along the
 					x-axis (in pixels, lines, or pages) to be scrolled in the case
 					where the event is not cancelled. Otherwise, this is an
@@ -3408,7 +3408,7 @@ function tilt2spherical(tiltX, tiltY) {
 
 				<dt><dfn>deltaY</dfn></dt>
 				<dd>
-					In user agents where the default action of the [=wheel=]
+					In user agents where the default action of the {{wheel}}
 					event is to scroll, the value MUST be the measurement along the
 					y-axis (in pixels, lines, or pages) to be scrolled in the case
 					where the event is not cancelled. Otherwise, this is an
@@ -3421,7 +3421,7 @@ function tilt2spherical(tiltX, tiltY) {
 
 				<dt><dfn>deltaZ</dfn></dt>
 				<dd>
-					In user agents where the default action of the [=wheel=]
+					In user agents where the default action of the {{wheel}}
 					event is to scroll, the value MUST be the measurement along the
 					z-axis (in pixels, lines, or pages) to be scrolled in the case
 					where the event is not cancelled. Otherwise, this is an
@@ -3492,14 +3492,14 @@ function tilt2spherical(tiltX, tiltY) {
 
 	<h4 id="events-wheel-types">Wheel Event Types</h4>
 
-		<h5 id="event-type-wheel"><dfn>wheel</dfn></h5>
+		<h5><dfn class="export" data-dfn-type="event">wheel</dfn></h5>
 
 <table class="event-definition">
     <tbody>
     	<tr>
     	<th>Type</th>
     	<td><strong><code>wheel</code></strong></td>
-		</tr>                                                  |
+		</tr>
 		<tr>
 			<th>Interface</th>
 			<td>{{WheelEvent}}</td>
@@ -3561,10 +3561,10 @@ function tilt2spherical(tiltX, tiltY) {
 			(such as a mouse-ball, certain tablets or touchpads, etc.) has
 			emulated such an action. Depending on the platform and input device,
 			diagonal wheel <a>deltas</a> MAY be delivered either as a single
-			[=wheel=] event with multiple non-zero axes or as separate
-			[=wheel=] events for each non-zero axis.
+			{{wheel}} event with multiple non-zero axes or as separate
+			{{wheel}} events for each non-zero axis.
 
-			The typical <a>default action</a> of the [=wheel=] event type is
+			The typical <a>default action</a> of the {{wheel}} event type is
 			to scroll (or in some cases, zoom) the document by the indicated
 			amount.  If this event is canceled, the implementation MUST NOT
 			scroll or zoom the document (or perform whatever other

--- a/index.html
+++ b/index.html
@@ -1252,7 +1252,7 @@ dictionary MouseEventInit : EventModifierInit {
 
 			<ol class="algorithm">
 			<li>Let |native| be the native mousedown or pointer event</li>
-			<li>Let |target| be the {{EventTarget}} of the event</li>
+			<li>Let |target| be the {{EventTarget}} of the event
 				<ol class="algorithm">
 			    <li>Let |menuevent| be the result of <a>creating a PointerEvent</a> with "contextmenu", |target|</li>
 				<li>If |native| is valid, then

--- a/index.html
+++ b/index.html
@@ -4302,6 +4302,8 @@ window.addEventListener("pointermove", function(event) {
                 <dd>A hardware-agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen, such as a mouse, pen, or touch contact.</dd>
             <dt><dfn>rotation</dfn></dt>
                 <dd>An indication of incremental change on an input device using the {{WheelEvent}} interface. On some devices this MAY be a literal rotation of a wheel, while on others, it MAY be movement along a flat surface, or pressure on a particular button.</dd>
+            <dt><dfn>topmost event target</dfn></dt>
+            <dd>The <a>topmost event target</a> MUST be the element highest in the rendering order which is capable of being a [=Event/target=]. In graphical user interfaces this is the element under the user's pointing device. A user interface's <q>hit testing</q> facility is used to determine the target. For specific details regarding hit testing and stacking order, refer to the <a>host language</a>.</dd>
         </dl>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -1053,7 +1053,7 @@ dictionary MouseEventInit : EventModifierInit {
             </li>
 			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
 
-			<li>Let |targetDomPath| = <a>calculate DOM path</a></li>
+			<li>Let |targetDomPath| = [=tree/inclusive ancestors=] of |target|</li>
 
 			<li>Generate events for leaving the current element:
 

--- a/index.html
+++ b/index.html
@@ -3329,6 +3329,322 @@ function tilt2spherical(tiltX, tiltY) {
         </section>
     </section>
 
+    	<section>
+<h3 id="events-wheelevents">Wheel Events</h3>
+
+	Wheels are devices that can be rotated in one or more spatial dimensions, and which can be associated with a pointer device. The coordinate system depends on the
+	environment configuration.
+
+	<p class="example">
+	The user's environment might be configured to associate vertical scrolling
+	with rotation along the y-axis, horizontal scrolling with rotation along the
+	x-axis, and zooming with rotation along the z-axis.
+	</p>
+
+	The deltaX, deltaY, and deltaZ attributes of {{WheelEvent}} objects indicate
+	a measurement along their respective axes in units of pixels, lines, or
+	pages. The reported measurements are provided after an environment-specific
+	algorithm translates the actual rotation/movement of the wheel device into
+	the appropriate values and units.
+
+	<p class="note">
+	A user's environment settings can be customized to interpret actual rotation/movement
+	of a wheel device in different ways.
+	One movement of a common <q>dented</q> mouse wheel can produce a measurement of 162 pixels
+	(162 is just an example value, actual values can depend on the current screen
+	dimensions of the user-agent).
+	But a user can change their default environment settings to speed-up their mouse wheel,
+	increasing this number.
+	Furthermore, some mouse wheel software can support acceleration (the faster the wheel
+	is rotated/moved, the greater the <a>delta</a> of each measurement) or even sub-pixel <a>rotation</a>
+	measurements.
+	Because of this, authors can not assume a given <a>rotation</a> amount in one user agent will
+	produce the same <a>delta</a> value in all user agents.
+	</p>
+
+	The sign (positive or negative) of the values of the deltaX, deltaY, and deltaZ attributes
+	MUST be consistent between multiple dispatches of the
+	EVENT{wheel} event while the
+	motion of the actual wheel device is rotating/moving in the same direction.
+	If a user agent scrolls as the default action of the
+	EVENT{wheel} event then the sign
+	of the <a>delta</a> SHOULD be given by a right-hand coordinate system where positive X,
+	Y, and Z axes are directed towards the right-most edge, bottom-most edge, and farthest
+	depth (away from the user) of the document, respectively.
+
+	<p class="note">
+	Individual user agents can (depending on their environment and hardware configuration)
+	interpret the same physical user interaction on the wheel differently.
+	For example, a vertical swipe on the edge of a trackpad from top to bottom can be
+	interpreted as a wheel action intended to either scroll the
+	page down or to pan the page up (i.e., resulting in either a positive or negative
+	deltaY value respectively).
+	</p>
+
+	A <a data-cite="infra">user agent</a> MUST create a <a>wheel event transaction</a> when the first wheel event
+	is fired, so that all subsequent wheel events within a implementation-specific amount of
+	time can be targetted at the same element. A <dfn>wheel event transaction</dfn> is series of
+	wheel events that are associated with a single user gesture. The
+	<a>wheel event transaction</a> MUST have an associated event target that is the
+	<a>topmost event target</a> at the time the first wheel event occurs in the group.
+
+	<p class="example">
+	If a series of wheel events targetted in a scrollable element start above a child element,
+	later events for the same user gesture may occur over the child element.
+	</p>
+
+	<h4 id="interface-wheelevent">Interface WheelEvent</h4>
+
+		The {{WheelEvent}} interface provides specific contextual information
+		associated with EVENT{wheel} events.
+
+		To create an instance of the {{WheelEvent}} interface, use the {{WheelEvent}} constructor,
+		passing an optional {{WheelEventInit}} dictionary.
+
+		<h5 id="idl-wheelevent">WheelEvent</h5>
+
+			<pre class="idl">
+			[Exposed=Window]
+			interface WheelEvent : MouseEvent {
+				constructor(DOMString type, optional WheelEventInit eventInitDict = {});
+				// DeltaModeCode
+				const unsigned long DOM_DELTA_PIXEL = 0x00;
+				const unsigned long DOM_DELTA_LINE	= 0x01;
+				const unsigned long DOM_DELTA_PAGE	= 0x02;
+
+				readonly attribute double deltaX;
+				readonly attribute double deltaY;
+				readonly attribute double deltaZ;
+				readonly attribute unsigned long deltaMode;
+			};
+			</pre>
+
+			<dl data-dfn-for="WheelEvent" data-link-for="WheelEvent">
+				<dt><dfn>DOM_DELTA_PIXEL</dfn></dt>
+				<dd>
+					The units of measurement for the <a>delta</a> MUST be pixels.
+					This is the most typical case in most operating system and
+					implementation configurations.
+				</dd>
+
+				<dt><dfn>DOM_DELTA_LINE</dfn></dt>
+				<dd>
+					The units of measurement for the <a>delta</a> MUST be individual
+					lines of text.  This is the case for many form controls.
+				</dd>
+
+				<dt><dfn>DOM_DELTA_PAGE</dfn></dt>
+				<dd>
+					The units of measurement for the <a>delta</a> MUST be pages,
+					either defined as a single screen or as a demarcated page.
+				</dd>
+
+				<dt><dfn>deltaX</dfn></dt>
+				<dd>
+					In user agents where the default action of the EVENT{wheel}
+					event is to scroll, the value MUST be the measurement along the
+					x-axis (in pixels, lines, or pages) to be scrolled in the case
+					where the event is not cancelled. Otherwise, this is an
+					implementation-specific measurement (in pixels, lines, or pages)
+					of the movement of a wheel device around the x-axis.
+
+					The <a>un-initialized value</a> of this attribute MUST be
+					<code>0.0</code>.
+				</dd>
+
+				<dt><dfn>deltaY</dfn></dt>
+				<dd>
+					In user agents where the default action of the EVENT{wheel}
+					event is to scroll, the value MUST be the measurement along the
+					y-axis (in pixels, lines, or pages) to be scrolled in the case
+					where the event is not cancelled. Otherwise, this is an
+					implementation-specific measurement (in pixels, lines, or pages)
+					of the movement of a wheel device around the y-axis.
+
+					The <a>un-initialized value</a> of this attribute MUST be
+					<code>0.0</code>.
+				</dd>
+
+				<dt><dfn>deltaZ</dfn></dt>
+				<dd>
+					In user agents where the default action of the EVENT{wheel}
+					event is to scroll, the value MUST be the measurement along the
+					z-axis (in pixels, lines, or pages) to be scrolled in the case
+					where the event is not cancelled. Otherwise, this is an
+					implementation-specific measurement (in pixels, lines, or pages)
+					of the movement of a wheel device around the z-axis.
+
+					The <a>un-initialized value</a> of this attribute MUST be
+					<code>0.0</code>.
+				</dd>
+
+				<dt><dfn>deltaMode</dfn></dt>
+				<dd>
+					The <code>deltaMode</code> attribute contains an indication of
+					the units of measurement for the <a>delta</a> values. The
+					default value is {{WheelEvent/DOM_DELTA_PIXEL}} (pixels).
+
+					This attribute MUST be set to one of the DOM_DELTA constants to
+					indicate the units of measurement for the <a>delta</a> values.
+					The precise measurement is specific to device, operating system,
+					and application configurations.
+
+					The <a>un-initialized value</a> of this attribute MUST be
+					<code>0</code>.
+				</dd>
+			</dl>
+
+		<h5 id="idl-wheeleventinit">WheelEventInit</h5>
+
+			<pre class="idl">
+			dictionary WheelEventInit : MouseEventInit {
+				double deltaX = 0.0;
+				double deltaY = 0.0;
+				double deltaZ = 0.0;
+				unsigned long deltaMode = 0;
+			};
+			</pre>
+
+			<dl dfn-for="WheelEventInit">
+				<dt><dfn dict-member>deltaX</dfn></dt>
+				<dd>See <code>deltaZ</code> attribute.</dd>
+
+				<dt><dfn dict-member>deltaY</dfn></dt>
+				<dd>See <code>deltaZ</code> attribute.</dd>
+
+				<dt><dfn dict-member>deltaZ</dfn></dt>
+				<dd>
+					Initializes the {{WheelEvent/deltaZ}} attribute of the {{WheelEvent}}
+					object. Relative positive values for this attribute (as well as
+					the {{WheelEvent/deltaX}} and {{WheelEvent/deltaY}} attributes) are
+					given by a right-hand coordinate system where the X, Y, and Z
+					axes are directed towards the right-most edge, bottom-most edge,
+					and farthest depth (away from the user) of the document,
+					respectively. Negative relative values are in the respective
+					opposite directions.
+				</dd>
+
+				<dt><dfn dict-member>deltaMode</dfn></dt>
+				<dd>
+					Initializes the {{WheelEvent/deltaMode}} attribute on the
+					{{WheelEvent}} object to the enumerated values 0, 1, or 2, which
+					represent the amount of pixels scrolled
+					({{WheelEvent/DOM_DELTA_PIXEL}}), lines scrolled
+					({{WheelEvent/DOM_DELTA_LINE}}), or pages scrolled
+					({{WheelEvent/DOM_DELTA_PAGE}}) if the <a>rotation</a> of the
+					wheel would have resulted in scrolling.
+				</dd>
+			</dl>
+
+	<h4 id="events-wheel-types">Wheel Event Types</h4>
+
+		<h5 id="event-type-wheel"><dfn>wheel</dfn></h5>
+
+<table class="event-definition">
+    <tbody>
+    	<tr>
+    	<th>Type</th>
+    	<td><strong><code>wheel</code></strong></td>
+		</tr>                                                  |
+		<tr>
+			<th>Interface</th>
+			<td>{{WheelEvent}}</td>
+			</tr>
+		<tr>
+			<th>Sync / Async</th>
+			<td>Async</td>
+			</tr>
+		<tr>
+			<th>Bubbles</th>
+			<td>Yes</td>
+			</tr>
+		<tr>
+			<th>Trusted Targets</th>
+			<td><code>Element</code></td>
+			</tr>
+		<tr>
+			<th>Cancelable</th>
+			<td><a href="#cancelability-of-wheel-events">Varies</td>
+			</tr>
+		<tr>
+			<th>Composed</th>
+			<td>Yes</td>
+			</tr>
+		<tr>
+			<th>Default action </th>
+			<td>Scroll (or zoom) the document</td>
+			</tr>
+		<tr>
+			<th>Context<br> (trusted events)</th>
+			<td>
+				<ul>
+				<li>{{Event}}.{{Event/target}} : element target for the current <a>wheel event transaction</a></li>
+				<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+				<li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/screenX}} : if the wheel is associated with a pointing device, the value based on the pointer position on the screen, otherwise <code>0</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/screenY}} : if the wheel is associated with a pointing device, the value based on the pointer position on the screen, otherwise <code>0</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/clientX}} : if the wheel is associated with a pointing device, the value based on the pointer position within the viewport, otherwise <code>0</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/clientY}} : if the wheel is associated with a pointing device, the value based on the pointer position within the viewport, otherwise <code>0</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class="keycap">Shift</code> modifier was active, otherwise <code>false</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class="keycap">Meta</code> modifier was active, otherwise <code>false</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/button}} : if wheel is associated with a pointing device, value based on current button pressed, otherwise <code>0</code></li>
+				<li>{{MouseEvent}}.{{MouseEvent/buttons}} : if wheel is associated with a pointing device, value based on all buttons current depressed, <code>0</code> if no buttons pressed</li>
+				<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : indicates the [=Event/target=] the pointing device is pointing at, if any</li>
+				<li>{{WheelEvent}}.{{WheelEvent/deltaX}} : expected amount that the page will scroll along the x-axis according to the deltaMode units; or an implementation-specific value of movement of a wheel around the x-axis</li>
+				<li>{{WheelEvent}}.{{WheelEvent/deltaY}} : expected amount that the page will scroll along the y-axis according to the deltaMode units; or an implementation-specific value of movement of a wheel around the y-axis</li>
+				<li>{{WheelEvent}}.{{WheelEvent/deltaZ}} : expected amount that the page will scroll along the z-axis according to the deltaMode units; or an implementation-specific value of movement of a wheel around the z-axis</li>
+				<li>{{WheelEvent}}.{{WheelEvent/deltaMode}} : unit indicator (pixels, lines, or pages) for the deltaX, deltaY, and deltaZ attributes</li>
+				</ul>
+			 </td>
+		</tr>
+	</tbody>
+</table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a mouse wheel has
+			been rotated around any axis, or when an equivalent input device
+			(such as a mouse-ball, certain tablets or touchpads, etc.) has
+			emulated such an action. Depending on the platform and input device,
+			diagonal wheel <a>deltas</a> MAY be delivered either as a single
+			EVENT{wheel} event with multiple non-zero axes or as separate
+			EVENT{wheel} events for each non-zero axis.
+
+			The typical <a>default action</a> of the EVENT{wheel} event type is
+			to scroll (or in some cases, zoom) the document by the indicated
+			amount.  If this event is canceled, the implementation MUST NOT
+			scroll or zoom the document (or perform whatever other
+			implementation-specific default action is associated with this event
+			type).
+
+			<p class="note">
+			In some <a data-cite="infra">user agents</a>, or with some input devices, the speed
+			that the wheel has been turned can affect the <a>delta</a> values,
+			with a faster speed producing a higher <a>delta</a> value.
+			</p>
+
+		<h5 id="cancelability-of-wheel-events">cancelability of wheel events</h5>
+			<p>
+			Calling <code>preventDefault</code> on a wheel event can prevent
+			or otherwise interrupt scrolling. For maximum scroll performance, a
+			user agent may not wait for each wheel event associated with the scroll
+			to be processed to see if it will be canceled. In such cases the user
+			agent should generate <code>wheel</code> events whose
+			<code>cancelable</code> property is <code>false</code>, indicating that
+			<code>preventDefault</code> cannot be used to prevent or interrupt
+			scrolling. Otherwise <code>cancelable</code> will be <code>true</code>.
+			</p>
+
+			<p>
+			In particular, a user agent should generate only uncancelable
+			<code>wheel</code> events when it
+			<a href="https://dom.spec.whatwg.org/#observing-event-listeners">observes
+			that there are no non-passive listeners</a> for the event.
+			</p>
+
+
+</section>
+
     <section>
         <h1>Extensions to the `Element` interface</h1>
         <div>
@@ -4067,6 +4383,9 @@ window.addEventListener("pointermove", function(event) {
                 <dd>An event whose default action was prevented by means of <code>preventDefault()</code>, returning <code>false</code> in an event handler, or other means as defined by [[UIEVENTS]] and [[HTML]].</dd>
             <dt><dfn>contact geometry</dfn></dt>
                 <dd>The bounding box of an input (most commonly, touch) on a digitizer. This typically refers to devices with coarser pointer input resolution than a single pixel. Some devices do not report this data at all.</dd>
+            <dt><dfn>delta</dfn></dt>
+                <dd>The estimated scroll amount (in pixels, lines, or pages) that the user agent will scroll or zoom the page in response to the physical movement of an input device that supports the {{WheelEvent}} interface (such as a mouse wheel or touch pad). The value of a <a>delta</a> (e.g., the {{WheelEvent/deltaX}}, {{WheelEvent/deltaY}}, or {{WheelEvent/deltaZ}} attributes) is to be interpreted in the context of the current {{WheelEvent/deltaMode}} property. The relationship between the physical movement of a wheel (or other device) and whether the <a>delta</a> is positive or negative is environment and device dependent. However, if a user agent scrolls as the <a>default action</a> then the sign of the <a>delta</a> is given by a right-hand coordinate system where positive X,Y, and Z axes are directed towards the right-most edge, bottom-most edge, and farthest depth (away from the user) of the <a for=/>document</a>, respectively.</dd>
+
             <dt><dfn>digitizer</dfn></dt>
                 <dd>A type of input sensing device in which a surface can detect input which is in contact and/or in close proximity. Most commonly, this is the surface that senses input from the touch contact or a pen/stylus.</dd>
             <dt><dfn>direct manipulation</dfn></dt>
@@ -4092,6 +4411,8 @@ window.addEventListener("pointermove", function(event) {
                     </dd>
             <dt><dfn>pointer</dfn></dt>
                 <dd>A hardware-agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen, such as a mouse, pen, or touch contact.</dd>
+            <dt><dfn>rotation</dfn></dt>
+                <dd>An indication of incremental change on an input device using the {{WheelEvent}} interface. On some devices this MAY be a literal rotation of a wheel, while on others, it MAY be movement along a flat surface, or pressure on a particular button.</dd>
         </dl>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -51,10 +51,10 @@
             noIDLSorting: true,
             doJsonLd: true,
             xref: {
-                specs: ["uievents"],
+                specs: ["uievents", "css2"],
                 profile: "web-platform"
             },
-            mdn: "pointerevents"
+            mdn: "pointerevents",
         };
     </script>
     <style>
@@ -62,6 +62,106 @@
         pre.idl::before, pre.example::before { font-family: sans-serif !important; }
         ol:not([data-class='note-list'])>li { margin-bottom: 1em; }
         img, video { max-width: 100%; }
+        .intro-dom {
+        	font-size: 0.9em;
+	        font-style: italic;
+        }
+        /* Denotes a string displayed on the keycap. */
+        code.keycap {
+        	padding: 0 2px;
+        	border: 1px solid black;
+        	border-radius: 3px;
+        }
+
+        @media screen and (prefers-color-scheme: dark) {
+            code.keycap {
+        	    border: 1px solid lightgray;
+            }
+        }
+/* Formatting for the event sequence tables.
+ */
+.event-sequence-table th {
+	background:none repeat scroll 0 0 #E8EDFF;
+	font-weight:normal;
+	padding: 0.25em 0.5em 0.25em 0.5em;
+	font-size: 0.9em;
+}
+
+.event-sequence-table td {
+	padding: 0 0.5em 0 0.5em;
+	font-size: 0.8em;
+	vertical-align: top;
+}
+
+.event-sequence-table tr:hover td {
+    background:none repeat scroll 0 0 #E8EDFF;
+}
+
+@media screen and (prefers-color-scheme: dark) {
+	.event-sequence-table th {background: none repeat scroll 0 0 #203785;}
+	.event-sequence-table tr:hover td {background:none repeat scroll 0 0 #203785;}
+}
+
+.example .event-sequence-table {
+    border: 1px solid #000000;
+    margin: 3px;
+}
+
+.example .event-sequence-table td {
+	background:none repeat scroll 0 0 #FCFAEE;
+}
+
+.example .event-sequence-table th {
+	background:none repeat scroll 0 0 #ede19b;
+}
+
+.example .event-sequence-table tr:hover td {
+    background:none repeat scroll 0 0 #ede19b;
+}
+
+
+@media screen and (prefers-color-scheme: dark) {
+	.example .event-sequence-table {border: 1px solid lightgray;}
+	.example .event-sequence-table th {background: none repeat scroll 0 0 #8a7a1a;}
+	.example .event-sequence-table td {background: none repeat scroll 0 0 #514c2b;}
+	.example .event-sequence-table tr:hover td {background:none repeat scroll 0 0 #8a7a1a;}
+}
+
+.cell-center {
+	text-align: center;
+}
+
+.cell-number {
+	text-align: right;
+}
+.event-definition {
+    border: 2px solid black;
+    width: 95%;
+}
+.event-definition td,
+.event-definition th {
+    padding-left: 8px;
+    padding-right: 8px;
+    font-size: 0.9em;
+}
+.event-definition th {
+    text-align: left;
+    font-weight: normal;
+    white-space: nowrap;
+    background-color: #D0DAFD;
+}
+.event-definition td {
+    width: 100%;
+}
+.event-definition td > ul > li,
+.event-definition td > ul > li > p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+@media screen and (prefers-color-scheme: dark) {
+	.event-definition {border: 2px solid lightgray;}
+	.event-definition th {background: none repeat scroll 0 0 #203785;}
+}
     </style>
 </head>
 <body>
@@ -75,7 +175,7 @@
 
     <section id="intro" class="informative">
         <h1>Introduction</h1>
-        <p>Today, most [[HTML]] content is used with and/or designed for mouse input. Those that handle input in a custom manner typically code to [[UIEVENTS]] Mouse Events. Newer computing devices today, however, incorporate other forms of input, including touchscreens and pen input. Event types have been proposed for handling each of these forms of input individually. However, that approach often incurs unnecessary duplication of logic and event handling overhead when adding support for a new input type. This often creates a compatibility problem when content is written with only one device type in mind. Additionally, for compatibility with existing mouse-based content, most [=user agents=] fire Mouse Events for all input types. This makes it ambiguous whether a Mouse Event represents an actual mouse device or is being produced from another input type for compatibility, which makes it hard to code to both device types simultaneously.</p>
+        <p>Today, most [[HTML]] content is used with and/or designed for mouse input. Those that handle input in a custom manner typically code to [[UIEVENTS]] Mouse Events. Newer computing devices today, however, incorporate other forms of input, including touchscreens and pen input. Event types have been proposed for handling each of these forms of input individually. However, that approach often incurs unnecessary duplication of logic and event handling overhead when adding support for a new input type. This often creates a compatibility problem when content is written with only one device type in mind. Additionally, for compatibility with existing mouse-based content, most  <a data-cite="infra">user agents</a> fire Mouse Events for all input types. This makes it ambiguous whether a Mouse Event represents an actual mouse device or is being produced from another input type for compatibility, which makes it hard to code to both device types simultaneously.</p>
 
         <p>To reduce the cost of coding to multiple input types and also to help with the above described ambiguity with Mouse Events, this specification defines a more abstract form of input, called a <a>pointer</a>. A pointer can be any point of contact on the screen made by a mouse cursor, pen, touch (including multi-touch), or other pointing input device. This model makes it easier to write sites and applications that work well no matter what hardware the user has. For scenarios when device-specific handling is desired, this specification also defines properties for inspecting the device type which produced the event. The primary goal is to provide a single set of events and interfaces that allow for easier authoring for cross-device pointer input while still allowing for device-specific handling only when necessary for an augmented experience.</p>
         <p>An additional key goal is to enable multi-threaded user agents to handle <a>direct manipulation</a> actions for panning and zooming (for instance, with a finger or stylus on a touchscreen), without blocking on script execution.</p>
@@ -223,6 +323,2165 @@ eventTarget.dispatchEvent(event2);</code>
 </pre>
     </section>
 
+        <h3>Mouse Events</h3>
+	<p>
+        The mouse event module originates from the [[HTML401]] <code>onclick</code>, <code>ondblclick</code>, <code>onmousedown</code>, <code>onmouseup</code>,	<code>onmouseover</code>, <code>onmousemove</code>, and	<code>onmouseout</code> attributes. This event module is specifically designed for use with pointing input devices, such as a mouse or a trackball.
+    </p>
+	    <h4>Interface MouseEvent</h4>
+		<p class="intro-dom">Introduced in DOM Level 2, modified in this specification.</p>
+		<p>
+            The {{MouseEvent}} interface provides specific contextual information associated with Mouse events.
+        </p>
+        <p>
+		    In the case of nested elements, mouse events are always targeted at the most deeply nested element.
+        </p>
+		<p class="note">
+		    Ancestors of the targeted element can use event bubbling to obtain notifications of mouse events which occur within their descendent elements.
+		</p>
+        <p>
+		    To create an instance of the {{MouseEvent}} interface, use the {{MouseEvent}} constructor, passing an optional {{MouseEventInit}} dictionary.
+        </p>
+		<p class="note">
+		    When initializing {{MouseEvent}} objects using <code>initMouseEvent</code>,	implementations can use the client coordinates {{MouseEvent/clientX}} and {{MouseEvent/clientY}} for calculation of other coordinates (such	as target coordinates exposed by DOM Level 0 implementations or	other proprietary attributes, e.g., <code>pageX</code>).
+		</p>
+
+		    <h5>MouseEvent</h5>
+			<pre class="idl">
+[Exposed=Window]
+interface MouseEvent : UIEvent {
+	constructor(DOMString type, optional MouseEventInit eventInitDict = {});
+	readonly attribute long screenX;
+	readonly attribute long screenY;
+	readonly attribute long clientX;
+	readonly attribute long clientY;
+	readonly attribute long layerX;
+	readonly attribute long layerY;
+
+	readonly attribute boolean ctrlKey;
+	readonly attribute boolean shiftKey;
+	readonly attribute boolean altKey;
+	readonly attribute boolean metaKey;
+
+	readonly attribute short button;
+	readonly attribute unsigned short buttons;
+
+	readonly attribute EventTarget? relatedTarget;
+
+	boolean getModifierState(DOMString keyArg);
+};
+			</pre>
+
+			<dl data-dfn-for="MouseEvent">
+				<dt><dfn>screenX</dfn></dt>
+				<dd>
+					<p>
+                        The horizontal coordinate at which the event occurred relative to the origin of the screen coordinate system.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>screenY</dfn></dt>
+				<dd>
+					<p>
+                        The vertical coordinate at which the event occurred relative to the origin of the screen coordinate system.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>clientX</dfn></dt>
+				<dd>
+					<p>
+                        The horizontal coordinate at which the event occurred relative to the viewport associated with the event.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>clientY</dfn></dt>
+				<dd>
+					<p>
+                        The vertical coordinate at which the event occurred relative to the viewport associated with the event.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>layerX</dfn></dt>
+				<dd>
+					<p>
+                        The horizontal offset from the nearest [=tree/ancestor=] element which is a [=stacking context=], is <a data-cite="css-position">positioned</a>, or paints in the positioned phase when <a data-cite="css-position" data-lt="paint a stacking context">painting a stacking context</a>.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>layerY</dfn></dt>
+				<dd>
+					<p>
+                        The vertical offset from the nearest [=tree/ancestor=] element which is a [=stacking context=], is <a data-cite="css-position">positioned</a>, or paints in the	positioned phase when <a data-cite="css-position" data-lt="paint a stacking context">painting a stacking context</a>.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>ctrlKey</dfn></dt>
+				<dd>
+					<p>
+                        Refer to the {{KeyboardEvent}}'s {{KeyboardEvent/ctrlKey}} attribute.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>false</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>shiftKey</dfn></dt>
+				<dd>
+					<p>
+                        Refer to the {{KeyboardEvent}}'s {{KeyboardEvent/shiftKey}} attribute.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>false</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>altKey</dfn></dt>
+				<dd>
+					<p>
+                        Refer to the {{KeyboardEvent}}'s {{KeyboardEvent/altKey}} attribute.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>false</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>metaKey</dfn></dt>
+				<dd>
+					<p>
+                        Refer to the {{KeyboardEvent}}'s {{KeyboardEvent/metaKey}} attribute.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>false</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>button</dfn></dt>
+				<dd>
+					<p>
+                        During mouse events caused by the depression or release of a mouse button, {{MouseEvent/button}} MUST be used to indicate which pointer device button changed state.
+                    </p>
+					<p>
+                        The value of the {{MouseEvent/button}} attribute MUST be as follows:
+                    </p>
+					<ul>
+                        <li>
+                            <code>0</code> MUST indicate the primary button of the device (in general, the left button  or the only button on single-button devices, used to activate a user interface control or select text) or the un-initialized value.
+                        </li>
+					    <li>
+                            <code>1</code> MUST indicate the auxiliary button (in general, the middle button, often combined with a mouse wheel).
+                        </li>
+					    <li>
+                            <code>2</code> MUST indicate the secondary button (in general, the right button, often used to display a context menu).
+                        </li>
+					    <li>
+                            <code>3</code> MUST indicate the X1 (back) button.
+                        </li>
+					    <li>
+                            <code>4</code> MUST indicate the X2 (forward) button.
+                        </li>
+                    </ul>
+					<p>
+                        Some pointing devices provide or simulate more button states, and values higher than <code>2</code> or lower than <code>0</code> MAY be used to represent such buttons.
+                    </p>
+					<p class="note">
+					    The value of {{MouseEvent/button}} is not updated for events not caused by the depression/release of a mouse button. In these scenarios, take care not to interpret the value <code>0</code> as the left button, but rather as the default value.
+					</p>
+					<p class="note">
+					    Some <a>default actions</a> related to events such as {{mousedown}} and {{mouseup}} depend on the specific mouse button in use.
+					</p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>buttons</dfn></dt>
+				<dd>
+					<p>
+                        During any mouse events, {{MouseEvent/buttons}} MUST be used to indicate which combination of mouse buttons are currently being pressed, expressed as a bitmask.
+                    </p>
+					<p class="note">
+					    Though similarly named, the values for the {{MouseEvent/buttons}} attribute and the {{MouseEvent/button}} attribute are very different. The value of {{MouseEvent/button}} is assumed to be valid during {{mousedown}} / {{mouseup}} event handlers, whereas the {{MouseEvent/buttons}} attribute reflects the state of the mouse's buttons for any trusted {{MouseEvent}} object (while it is being dispatched), because it can represent the "no button currently active" state (0).
+					</p>
+
+					<p>
+                        The value of the {{MouseEvent/buttons}} attribute MUST be as follows:
+                    </p>
+                    <ul>
+					    <li><code>0</code> MUST indicate no button is currently active.
+					    <li><code>1</code> MUST indicate the primary button of the device (in general, the left button or the only button on single-button devices, used to activate a user interface control or select text).
+					    <li><code>2</code> MUST indicate the secondary button (in general, the right button, often used to display a context menu), if present.
+					    <li><code>4</code> MUST indicate the auxiliary button (in general, the middle button, often combined with a mouse wheel).
+                    </li>
+                    </ul>
+					<p>
+                        Some pointing devices provide or simulate more buttons. To represent such buttons, the value MUST be doubled for each successive button (in the binary series <code>8</code>, <code>16</code>, <code>32</code>, ... ).
+                    </p>
+					<p class="note">
+					    Because the sum of any set of button values is a unique number, a content author can use a bitwise operation to determine how many buttons are currently being pressed and which buttons they are, for an arbitrary number of mouse buttons on a device. For example, the value <code>3</code> indicates that the left and right button are currently both pressed, while the value <code>5</code> indicates that the left and middle button are currently both pressed.
+                    </p>
+					<p class="note">
+					    Some <a>default actions</a> related to events such as {{mousedown}} and {{mouseup}} depend on the specific mouse button in use.
+					</p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>0</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn>relatedTarget</dfn></dt>
+				<dd>
+					<p>
+                        Used to identify a secondary {{EventTarget}} related to a UI event, depending on the type of event.
+                    </p>
+                    <p>
+                        The [=un-initialized value=] of this attribute MUST be <code>null</code>.
+                    </p>
+				</dd>
+
+				<dt><dfn method>getModifierState(keyArg)</dfn></dt>
+				<dd>
+                    <p>
+					    Queries the state of a modifier using a key value.
+                    </p>
+					<p>
+                        Returns <code>true</code> if it is a modifier key and the modifier is activated, <code>false</code> otherwise.
+                    </p>
+					<dl class="parameters">
+						<dt>{{DOMString}} keyArg</dt>
+						<dd>
+							Refer to the {{KeyboardEvent}}'s {{KeyboardEvent/getModifierState()}} method for a description of this parameter.
+						</dd>
+					</dl>
+				</dd>
+			</dl>
+
+		
+            <h5>MouseEventInit</h5>
+			<pre class="idl">
+dictionary MouseEventInit : EventModifierInit {
+	long screenX = 0;
+	long screenY = 0;
+	long clientX = 0;
+	long clientY = 0;
+
+	short button = 0;
+	unsigned short buttons = 0;
+	EventTarget? relatedTarget = null;
+};
+            </pre>
+			<dl dfn-for="MouseEventInit">
+				<dt><dfn>screenX</dfn></dt>
+				<dd>
+					<p>
+                        Initializes the {{MouseEvent/screenX}} attribute of the {{MouseEvent}} object to the desired horizontal relative position of the mouse pointer on the user's screen.
+                    </p>
+					<p>
+                        Initializing the event object to the given mouse position must not move the user's mouse pointer to the initialized position.
+                    </p>
+				</dd>
+
+				<dt><dfn>screenY</dfn></dt>
+				<dd>
+					<p>
+                        Initializes the {{MouseEvent/screenY}} attribute of the {{MouseEvent}} object to the desired vertical relative position of the mouse pointer on the user's screen.
+                    </p>
+					<p>
+                        Initializing the event object to the given mouse position must not move the user's mouse pointer to the initialized position.
+                    </p>
+				</dd>
+
+				<dt><dfn>clientX</dfn></dt>
+				<dd>
+					<p>
+                        Initializes the {{MouseEvent/clientX}} attribute of the {{MouseEvent}} object to the desired horizontal position of the mouse pointer relative to the client window of the user's browser.
+                    </p>
+					<p>
+                        Initializing the event object to the given mouse position must not move the user's mouse pointer to the initialized position.
+                    </p>
+				</dd>
+
+				<dt><dfn>clientY</dfn></dt>
+				<dd>
+					<p>
+                        Initializes the {{MouseEvent/clientY}} attribute of the {{MouseEvent}} object to the desired vertical position of the mouse pointer relative to the client window of the user's browser.
+                    </p>
+					<p>
+                        Initializing the event object to the given mouse position must not move the user's mouse pointer to the initialized position.
+                    </p>
+				</dd>
+
+				<dt><dfn>button</dfn></dt>
+				<dd>
+					<p>
+                        Initializes the {{MouseEvent/button}} attribute of the {{MouseEvent}} object to a number representing the desired state of the button(s) of the mouse.
+                    </p>
+					<p class="note">
+					    The value 0 is used to represent the primary mouse button, 1 is used to represent the auxiliary/middle mouse button, and 2 to represent the right mouse button. Numbers greater than 2 are also possible, but are not specified in this document.
+					</p>
+				</dd>
+
+				<dt><dfn>buttons</dfn></dt>
+				<dd>
+					<p>
+                        Initializes the {{MouseEvent/buttons}} attribute of the {{MouseEvent}} object to a number representing one <em>or more</em> of the button(s) of the mouse that are to be considered active.
+                    </p>
+					<p class="note">
+					    The {{MouseEvent/buttons}} attribute is a bit-field. If a mask value of 1 is true when applied to the value of the bit field, then the primary mouse button is down. If a mask value of 2 is true when applied to the value of the bit field, then the right mouse button is down. If a mask value of 4 is true when applied to the value of the bit field, then the auxiliary/middle button is down.
+					</p>
+					<div class="example">
+					<p>
+					    In JavaScript, to initialize the {{MouseEvent/buttons}} attribute as if the right (2) and middlebutton (4) were being pressed simultaneously, the buttons value can be assigned as either:
+                    </p>
+                    <pre class="code">{ buttons: 2 | 4 }</pre>
+					<p>or:</p>
+					<pre class="code">{ buttons: 6 }</pre>
+                    </div>
+				</dd>
+
+				<dt><dfn>relatedTarget</dfn></dt>
+				<dd>
+					<p>
+                        The {{relatedTarget}} should be initialized to the element whose bounds the mouse pointer just left (in the case of a {{mouseover}} or {{mouseenter}} event) or the element whose bounds the mouse pointer is entering (in the case of a {{mouseout}} or {{mouseleave}} or {{focusout}} event). For other events, this value need not be assigned (and will default to null).
+					</p>
+				</dd>
+			</dl>
+
+	        <p id="current-click-count">
+                Implementations MUST maintain the <dfn>current click count</dfn> when generating mouse events. This MUST be a non-negative integer indicating the number of consecutive clicks of a pointing device button within a specific time. The delay after which the count resets is specific to the environment configuration.
+	        </p>
+
+
+
+	    <h4>Event Modifier Initializers</h4>
+
+		<p>
+            The {{MouseEvent}} and {{KeyboardEvent}} interfaces share a set of keyboard modifier attributes and support a mechanism for retrieving additional modifier states. The following dictionary enables authors to initialize keyboard modifier attributes of the {{MouseEvent}} and {{KeyboardEvent}} interfaces, as well as the additional modifier states queried via {{KeyboardEvent/getModifierState()}}. The steps for constructing events using this dictionary are defined in the <a href="#constructing-mouse-events">MouseEvent constructors</a> section.
+        </p>
+		<pre class="idl">
+dictionary EventModifierInit : UIEventInit {
+	boolean ctrlKey = false;
+	boolean shiftKey = false;
+	boolean altKey = false;
+	boolean metaKey = false;
+
+	boolean modifierAltGraph = false;
+	boolean modifierCapsLock = false;
+	boolean modifierFn = false;
+	boolean modifierFnLock = false;
+	boolean modifierHyper = false;
+	boolean modifierNumLock = false;
+	boolean modifierScrollLock = false;
+	boolean modifierSuper = false;
+	boolean modifierSymbol = false;
+	boolean modifierSymbolLock = false;
+};
+		</pre>
+
+		<dl dfn-for="EventModifierInit">
+			<dt><dfn>ctrlKey</dfn></dt>
+			<dd>
+				<p>
+                    Initializes the <code>ctrlKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Control</code> key modifier is to be considered active, <code>false</code> otherwise.
+                </p>
+				<p>
+                    When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Control</code> must return <code>true</code>.
+                </p>
+			</dd>
+
+			<dt><dfn>shiftKey</dfn></dt>
+			<dd>
+            <p>
+                Initializes the <code>shiftKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Shift</code> key modifier is to be considered active, <code>false</code> otherwise.
+            </p>
+			<p>
+				When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Shift</code> must return <code>true</code>.
+			</dd>
+			<dt><dfn>altKey</dfn></dt>
+			<dd>
+				<p>
+                    Initializes the <code>altKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Alt</code> (alternative) (or <code class='keycap'>Option</code>) key modifier is to be considered active, <code>false</code> otherwise.
+                </p>
+				<p>
+                    When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Alt</code> must return <code>true</code>.
+                </p>
+			</dd>
+
+			<dt><dfn>metaKey</dfn></dt>
+			<dd>
+				<p>
+                    Initializes the <code>metaKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Meta</code> key modifier is to be considered active, <code>false</code> otherwise.
+                </p>
+				<p>
+				    When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with either the parameter <code class='keycap'>Meta</code> must return <code>true</code>.
+                </p>
+			</dd>
+
+			<dt><dfn>modifierAltGraph</dfn></dt>
+			<dd>
+				<p>
+                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>AltGraph</code> must return <code>true</code>.
+                </p>
+			</dd>
+
+			<dt><dfn>modifierCapsLock</dfn></dt>
+			<dd>
+				<p>
+                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>CapsLock</code> must return <code>true</code>.
+                </p>
+			</dd>
+
+			<dt><dfn>modifierFn</dfn></dt>
+			<dd>
+				<p>
+                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Fn</code> must return <code>true</code>.
+                </p>
+			</dd>
+
+			<dt><dfn>modifierFnLock</dfn></dt>
+			<dd>
+				<p>
+                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>FnLock</code> must return <code>true</code>.
+                </p>
+			</dd>
+
+			<dt><dfn>modifierHyper</dfn></dt>
+			<dd>
+				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Hyper</code> must return <code>true</code>.
+			</dd>
+
+			<dt><dfn>modifierNumLock</dfn></dt>
+			<dd>
+				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>NumLock</code> must return <code>true</code>.
+			</dd>
+
+			<dt><dfn>modifierScrollLock</dfn></dt>
+			<dd>
+				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>ScrollLock</code> must return <code>true</code>.
+			</dd>
+
+			<dt><dfn>modifierSuper</dfn></dt>
+			<dd>
+				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Super</code> must return <code>true</code>.
+			</dd>
+
+			<dt><dfn>modifierSymbol</dfn></dt>
+			<dd>
+				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Symbol</code> must return <code>true</code>.
+			</dd>
+
+			<dt><dfn>modifierSymbolLock</dfn></dt>
+			<dd>
+				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>SymbolLock</code> must return <code>true</code>.
+			</dd>
+		</dl>
+
+		
+            <h5>Constructing Mouse Events</h5>
+
+			<p>
+                Generally, when a constructor of an {{Event}} interface, or of an interface inherited from the {{Event}} interface, is invoked, the steps described in [[DOM]] should be followed. However the {{MouseEvent}} interfaces provide additional dictionary members for initializing the internal state of the {{Event}} object's key modifiers: specifically, the internal state queried for using the {{MouseEvent/getModifierState()}} methods. This section supplements the [[DOM]] steps for intializing a new {{MouseEvent}} object with these optional modifier states.
+            </p>
+			<p>
+                For the purposes of constructing a {{MouseEvent}}, or object derived from these objects using the algorithm below, all {{MouseEvent}}, and derived objects have <dfn>internal key modifier state</dfn> which can be set and retrieved using the <a data-cite="uievents/#keys-modifiers">key modifier names</a> described in the <a data-cite="UIEvents-Key/#keys-modifier">Modifier Keys table</a> in [[UIEvents-Key]].
+            </p>
+			<p>
+                The following steps supplement the algorithm defined for constructing events in [[DOM]]:
+            </p>
+            <ul>
+                <li>
+			        If the {{Event}} being constructed is a {{MouseEvent}} object or an object that derives from it, and a {{EventModifierInit}} argument was provided to the constructor, then run the following sub-steps:
+                    <ul>
+                        <li>
+                            For each {{EventModifierInit}} argument, if the dictionary member begins with the string <code>"modifier"</code>, then let the <dfn>key modifier name</dfn> be the dictionary member's name excluding the prefix <code>"modifier"</code>, and set the {{Event}} object's [=internal key modifier state=] that matches the [=key modifier name=] to the corresponding value.
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+
+
+
+
+	    <h4>MouseEvent Algorithms</h4>
+
+
+		    <h5>Native OS Requirements</h5>
+
+			<p>
+                The algorithms in this section assume that the native platform OS will provide the following:
+            </p>
+            <ul>
+			<li>An event when the mouse is moved (handled by <a>handle native mouse move</a>)</li>
+			<li>An event when a mouse button is pressed (handled by <a>handle native mouse down</a>)</li>
+			<li>An event when a mouse button is released (handled by <a>handle native mouse up</a>)</li>
+			<li>A way to identify when a mouse button press should be interpreted as a "click" (handled by <a>handle native mouse click</a>)
+				<ul>
+                    <li>For example, as a flag or as a separate event</li>
+				    <li>If a separate "click" event is fired, then the native OS will fire it immediately after the corresponding "mouse up" event, with no intervening mouse-related events</li>
+                </ul>
+            </li>
+			<li>A way to identify when a mouse click is a "double click" (handled by <a>handle native mouse double click</a>)</li>
+            </ul>
+            <p>
+			    For these events, the OS will be able to provide the following info:
+            </p>
+
+			<ul>
+                <li>The x,y mouse coordinates relative to the native OS desktop</li>
+			    <li>The x,y mouse coordinates relative to the UA's window viewport</li>
+			    <li>Which keyboard modifiers are currently being held</li>
+            </ul>
+
+
+		    <h5>Global State for MouseEvent</h5>
+
+
+			    <h6>User Agent-Level State</h6>
+
+				<p>
+                    The UA must maintain the following values that are shared for the entire User Agent.
+                </p>
+				<p>
+                    A <dfn>mouse button bitmask</dfn> that tracks the current state of the mouse buttons.
+                </p>
+
+
+			    <h6>Window-Level State</h6>
+
+				<p>
+                    The UA must maintain the following values that are shared for the Window.
+                </p>
+                <p>
+				    A <dfn>last mouse element</dfn> value (initially undefined) that keeps track of the last {{Element}} that we sent a MouseEvent to.
+                </p>
+                <p>
+				    A <dfn>last mouse DOM path</dfn> value (initially empty) that contains a snapshot of the ancestors {{Element}}s of the <a>last mouse element</a> when the most recent mouse event was sent.
+                </p>
+
+
+
+		    <h5>Internal State for MouseEvent</h5>
+
+			<p>
+                A {{MouseEvent}} has the following internal flags that are used to track the state of various modifier keys:
+				<dfn>shift flag</dfn>,
+				<dfn>control flag</dfn>,
+				<dfn>alt flag</dfn>,
+			    <dfn>altgraph flag</dfn>,
+				and <dfn>meta flag</dfn>.
+			These flags are set if the corresponding modifier key was pressed at the time
+			of the mouse event.
+            </p>
+
+		
+		    <h5>initialize a {{MouseEvent}}</h5>
+
+            <p>
+                To <dfn class="export">initialize a MouseEvent</dfn> with |event|, |eventType| and |eventTarget|, |bubbles|, and |cancelable|, run the following steps:
+            </p>
+			
+            <ol class="algorithm">
+                <li>
+                    [=Initialize a UIEvent=] with |event|, |eventType|, |eventTarget|, |bubbles| and |cancelable|.
+                </li>
+                <li>
+                    Set |event|.{{MouseEvent/screenX}} to the x-coordinate of the position where the event occurred relative to the origin of the desktop
+                </li>
+				<li>
+                    Set |event|.{{MouseEvent/screenY}} to the y-coordinate of the position where the event occurred relative to the origin of the desktop
+                </li>
+				<li>
+                    Set |event|.{{MouseEvent/clientX}} to the x-coordinate of the position where the event occurred relative to the origin of the <a data-cite="css2">viewport</a>
+                </li>
+				<li>
+                    Set |event|.{{MouseEvent/clientY}} to the y-coordinate of the position where the event occurred relative to the origin of the <a data-cite="css2">viewport</a>
+                </li>
+				<li>
+                    <a>Set mouse event modifiers</a> with |event|
+                </li>
+				<li>
+                    Set |event|.{{MouseEvent/button}} = 0
+                </li>
+				<li>
+                    Set |event|.{{MouseEvent/buttons}} = <a>mouse button bitmask</a>
+                </li>
+                <li>
+			        <a>Initialize PointerLock attributes for MouseEvent</a> with |event|
+                    <p class="issue">
+                        We should provide a hook for PointerLock instead of hardcoding it here.
+                    </p>
+                </li>
+            </ol>
+
+		
+
+		
+		    <h5><dfn>set mouse event modifiers</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |event| be the {{MouseEvent}} to update</li>
+			<li>Set |event|'s <a>shift flag</a> if <a>key modifier state</a> includes "Shift", unset it otherwise</li>
+			<li>Set |event|'s <a>control flag</a> if <a>key modifier state</a> includes "Control", unset it otherwise</li>
+			<li>Set |event|'s <a>alt flag</a> if <a>key modifier state</a> includes "Alt", unset it otherwise</li>
+		    <li>Set |event|'s <a>altgraph flag</a> if <a>key modifier state</a> includes "AltGraph", unset it otherwise</li>
+			<li>Set |event|'s <a>meta flag</a> if <a>key modifier state</a> includes "Meta", unset it otherwise</li>
+
+			<li>Set |event|.{{MouseEvent/shiftKey}} = true if the event's <a>shift flag</a> is set, false otherwise</li>
+			<li>Set |event|.{{MouseEvent/ctrlKey}} = true if the event's <a>control flag</a> is set, false otherwise</li>
+			<li>Set |event|.{{MouseEvent/altKey}} = true if the event's <a>alt flag</a> or <a>altgraph flag</a> is set, false otherwise</li>
+			<li>Set |event|.{{MouseEvent/metaKey}} = true if the event's <a>meta flag</a> is set, false otherwise</li>
+            </ol>
+		
+
+		
+		    <h5><dfn>create a cancelable MouseEvent</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |eventType|, a DOMString containing a valid {{MouseEvent}} type</li>
+			<li>Let |eventTarget|, the {{EventTarget}} of the event</li>
+			<li>Let |bubbles| be "true"</li>
+			<li>Let |cancelable| be "true"</li>
+
+			<li>Let |event| = the result of <a data-lt="creating an event">creating a new event</a> using {{MouseEvent}}</li>
+			<li><a>Initialize a MouseEvent</a> with |event|, |eventType|, |eventTarget|, |bubbles| and |cancelable|.</li>
+			<li>Return |event|</li>
+            </ol>
+
+		
+
+		
+		    <h5><dfn>create a non-cancelable MouseEvent</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |eventType|, a DOMString containing a valid {{MouseEvent}} type</li>
+			<li>Let |eventTarget|, the {{EventTarget}} of the event</li>
+			<li>Let |bubbles| be "false"</li>
+			<li>Let |cancelable| be "false"</li>
+
+			<li>Let |event| = the result of <a data-lt="creating an event">creating a new event</a> using {{MouseEvent}}</li>
+			<li><a>Initialize a MouseEvent</a> with |event|, |eventType|, |eventTarget|, |bubbles| and |cancelable|.</li>
+			<li>Return |event|</li>
+            </ol>
+
+		
+
+		
+		    <h5><dfn>calculate MouseEvent button attribute</dfn></h5>
+            <p>This will return a button ID suitable for storing in the {{MouseEvent}}'s {{MouseEvent/button}} attribute.</p>
+			<ol class="algorithm">
+			<li>Let |mbutton|, an ID that identifies a mouse button</li>
+			<li>If |mbutton| is the primary mouse button, then return 0</li>
+			<li>If |mbutton| is the auxiliary (middle)  mouse button, then return 1</li>
+			<li>If |mbutton| is the secondary mouse button, then return 2</li>
+			<li>If |mbutton| is the X1 (back) button, then return 3</li>
+			<li>If |mbutton| is the X2 (forward) button, then return 4</li>
+
+            </ol>
+		
+
+		
+		    <h5><dfn>set MouseEvent attributes from native</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |event|, the {{MouseEvent}} to initialize</li>
+			<li>Let |native|, the native mouse event
+			<p class="ednote">TODO.</p>
+                </li>
+			<li>If |event|.{{Event/type}} is one of [ mousedown, mouseup ], then
+                <ol>
+				<li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
+				<li>Set |event|.{{MouseEvent/button}} = <a>calculate MouseEvent button attribute</a> with |mbutton|</li>
+                </ol>
+            </li>
+            </ol>
+
+		
+
+		
+		    <h5><dfn>handle native mouse down</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |native|, the native mousedown</li>
+			<li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
+
+			<li>Update the <a>mouse button bitmask</a> as follows:
+                <ol>
+				<li>If |mbutton| is the primary mouse button, then set the 0x01 bit</li>
+				<li>If |mbutton| is the secondary mouse button, then set the 0x02 bit</li>
+				<li>If |mbutton| is the auxiliary (middle) mouse button, then set the 0x04 bit
+
+				<p class="note">
+				Other buttons can be added starting with 0x08 .
+				</p>
+                </li>
+                </ol></li>
+			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+			<li>Let |event| = <a>create a cancelable MouseEvent</a> with "mousedown", |target|</li>
+			<li><a>Set MouseEvent attributes from native</a> with |native|</li>
+			<li><a>Maybe send pointerdown event</a> with |event|</li>
+			<li>Let |result| = <a>dispatch</a> |event| at |target|</li>
+			<li>If |result| is true and |target| is a <a>focusable area</a> that is <a>click focusable</a>, then
+				<ol>
+                    <li>Run the <a>focusing steps</a> at |target|</li>
+                </ol>
+            </li>
+			<li>if |mbutton| is the secondary mouse button, then
+                <ol>
+				<li><a>Maybe show context menu</a> with |native|, |target|</li>
+                </ol>
+            </li>
+            </ol>
+		
+
+		
+		    <h5><dfn>handle native mouse up</dfn></h5>
+
+			<ol class="algorithm">
+			    <li>Let |native|, the native mouseup
+			    <p class="note">
+			    Other mouse events can occur between the mousedown and mouseup.
+			    </p>
+                </li>
+			    <li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
+
+			    <li>Update the <a>mouse button bitmask</a> as follows:
+				    <ol class="algorithm">
+			        <li>If |mbutton| is the primary mouse button, then clear the 0x01 bit</li>
+				    <li>If |mbutton| is the secondary mouse button, then clear the 0x02 bit</li>
+				    <li>If |mbutton| is the auxiliary (middle) mouse button, then clear the 0x04 bit</li>
+                    </ol>
+                </li>
+			    <li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+			    <li>Let |event| = <a>create a cancelable MouseEvent</a> with "mouseup", |target|</li>
+			    <li><a>Set MouseEvent attributes from native</a> with |native|</li>
+
+			    <li><a>Maybe send pointerup event</a> with |event|</li>
+
+			    <li><a>dispatch</a> |event| at |target|</li>
+            </ol>
+
+		
+
+		
+		    <h5><dfn>handle native mouse click</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |native|, the native mouse click
+			<p class="note">
+			The platform should call this immediately after <a>handle native mouse up</a> for mouseups that generate clicks.
+			</p>
+            </li>
+			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+
+			<li><a>Send click event</a> with |native| and |target|.</li>
+            </ol>
+		
+
+		
+		    <h5><dfn>send click event</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |native|, the native mousedown</li>
+			<li>Let |target|, the {{EventTarget}} of the event</li>
+			<li>Let |mbutton| = 1  (primary mouse button by default)</li>
+			<li>If |native| is valid, then
+				<ol class="algorithm">
+			    <li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
+                </ol>
+            </li>
+			<li>Set |eventType| = "click" if |mbutton| is the primary mouse button, otherwise "auxclick"</li>
+
+			<li>Let |event| = <a>create a PointerEvent</a> with |eventType| and |target|</li>
+
+			<li>If |native| is valid, then
+				<ol class="algorithm">
+			    <li><a>Set MouseEvent attributes from native</a> with |event|, |native|</li>
+				<li>If |event|.{{MouseEvent/screenX}} is not an integer value, then round it.</li>
+				<li>If |event|.{{MouseEvent/screenY}} is not an integer value, then round it.</li>
+                </ol>
+            </li>
+			<li><a>dispatch</a> |event| at |target|
+
+			<p class="note">
+			See <a href="https://github.com/w3c/pointerevents/issues/100">pointerevents/100</a>
+			for info about browsers using PointerEvents and rounded coordinates.
+			</p>
+
+			<p class="ednote">
+			Any "default action" is handled during dispatch by triggering the
+			<a href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">activation behavior</a>
+			algorithm for the target. So there is no need for handle that here.
+			However, need to verify that the existing spec handles disabled/css-pointer-events/inert/...
+			</p>
+
+			<p class="note">
+			To handle `HTMLelement.click()`, call this algorithm with |native| = null and |target| = `HTMLelement`.
+			</p>
+
+			<p class="note">
+			To handle keyboard-initiated clicks, call this algorithm with |native| = null and |target| = currently focused element.
+			</p>
+            </li>
+            </ol>
+		
+
+		
+		    <h5><dfn>handle native mouse double click</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |native|, the native mouse double click
+			<p class="note">
+			This should be called immediately after handle native mouse click for mouse clicks that generate double clicks.
+			</p>
+            </li>
+			<li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
+
+			<li>If |mbutton| is not the primary mouse button, then return</li>
+
+			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+
+			<li>Let |event| = <a>create a PointerEvent</a> with "dblclick" and |target|</li>
+			<li><a>Set MouseEvent attributes from native</a> with |event|, |native|</li>
+			<li>If |event|.{{MouseEvent/screenX}} is not an integer value, then round it.</li>
+			<li>If |event|.{{MouseEvent/screenY}} is not an integer value, then round it.</li>
+
+			<li><a>dispatch</a> |event| at |target|</li>
+            </ol>
+		
+
+		
+		    <h5><dfn>handle native mouse move</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |native|, the native mouse move
+			<p class="issue">
+			This algorithm makes assumptions about the dispatch of PointerEvents because they are not currently specified explicitly. Once <a href="https://github.com/w3c/pointerevents/issues/285">pointerevents/285</a> is resolved this may need to be updated.
+			</p>
+            </li>
+			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+
+			<li>Let |targetDomPath| = <a>calculate DOM path</a></li>
+
+			<li>Generate events for leaving the current element:
+
+				<ol class="algorithm">
+			    <li>If <a>last mouse element</a> is defined and not equal to |target|, then
+
+					<ol class="algorithm">
+			        <li>Let |mouseout| = <a>create a cancelable MouseEvent</a> with "mouseout" and <a>last mouse element</a>
+
+					<p class="ednote">
+					TODO: Set |mouseout| attributes from |native|. +CSSOM attributes.
+					</p>
+                    </li>
+                    </ol>
+					<li><a>Maybe send pointerout event</a> with |mouseout|</li>
+
+					<li><a>Dispatch</a> |mouseout| at |target|
+
+						<p class="note">
+						Verify behavior when canceled (appears to have no effect).
+						</p>
+                    </li>
+					<li>Let |leaveElements| be a copy of <a>last mouse DOM path</a> with all elements common to |targetDomPath| removed.</li>
+
+					<li>For each |element| in |leaveElements|, do
+
+						<p class="ednote">
+						Handle case where |element| has been deleted.
+						Also case where it has been moved: Should the DOM mutation have triggered
+						a mouseleave event? Should we sent it now? Should it be dropped?
+						Need to verify what current browsers do.
+						</p>
+
+						<ol class="algorithm">
+			            <li>Let |mouseleave| = <a>create a non-cancelable MouseEvent</a> with "mouseleave" and |element|</li>
+
+						<li>Set |mouseleave|.{{Event.composed}}
+ = false
+
+							<p class="note">
+							Check compat: Value of event.composed. Spec says false. Chrome/Linux = true. Firefox/Linux = false.
+							</p>
+                        </li>
+						<li><a>Maybe send pointerleave event</a> with |mouseleave|</li>
+
+						<li>Let |result| = <a>dispatch</a> |mouseleave| at |element|</li>
+                        </ol>
+                        </li>
+                </li>
+                </ol>
+            </li>
+			<li>Generate events for entering the new element:
+
+				<ol class="algorithm">
+			    <li>If |target| is not <a>last mouse element</a>, then
+
+					<ol class="algorithm">
+			        <li>Let |mouseover| = <a>create a cancelable MouseEvent</a> with "mouseover" and |target|
+
+					<p class="ednote">
+					TODO: Set |mouseout| attributes from |native|. +CSSOM attributes.
+					</p>
+                    </li>
+					<li><a>Maybe send pointerover event</a> with |mouseover|</li>
+
+					<li><a>Dispatch</a> |mouseout| at |target|
+
+						<p class="note">
+						Need to verify behavior when canceled (appears to have no effect).
+						</p>
+                    </li>
+					<li>Let |enterElements| be a copy of |targetDomPath| with all elements common to <a>last mouse DOM path</a> removed.</li>
+
+					<li>For each |element| in |enterElements|, do
+
+						<p class="note">
+						Handle case where |element| has been deleted or moved.
+						</p>
+
+						<ol class="algorithm">
+			            <li>Let |mouseenter| = <a>create a non-cancelable MouseEvent</a> with "mouseenter" and |element|</li>
+
+						<li>Set |mouseenter|.{{Event.composed}}
+ = false
+
+							<p class="note">
+							Check compat: Value of event.composed. Spec says false.
+							Chrome/Linux = true.
+							Firefox/Linux = false.
+							</p>
+                        </li>
+						<li><a>Maybe send pointerenter event</a> with |mouseenter|
+
+						<p class="note">
+						Check compat for shadow DOM elements. Chrome/Linux fires this event at the element and the shadow root.
+						</p>
+                        </li>
+						<li>Let |result| = <a>dispatch</a> |mouseenter| at |element|</li>
+                    </ol>
+                    </li>
+					<li>Set <a>last mouse element</a> to |target|</li>
+					<li>Set <a>last mouse DOM path</a> to |targetDomPath|</li>
+                    </ol>
+                </li>
+            </ol>
+            </li>
+			<li>Let |mousemove| = <a>create a cancelable MouseEvent</a> with "mousemove" and |element|</li>
+
+			<li><a>Set PointerLock attributes for mousemove</a></li>
+
+			<li><a>Maybe send pointermove event</a> with |mousemove|</li>
+
+			<li><a>Dispatch</a> |mousemove| at |element|</li>
+            </ol>
+		
+
+		
+		    <h5><dfn>maybe show context menu</dfn></h5>
+
+			<ol class="algorithm">
+			<li>Let |native|, the native mousedown or pointer event</li>
+			<li>Let |target|, the {{EventTarget}} of the event</li>
+				<ol class="algorithm">
+			    <li>Let |menuevent| = <a>create a PointerEvent</a> with "contextmenu", |target|</li>
+				<li>If |native| is valid, then
+					<ol class="algorithm">
+			        <li><a>Set MouseEvent attributes from native</a> with |native|</li>
+                    </ol>
+                </li>
+				<li>Let |result| = <a>dispatch</a> |menuevent| at |target|</li>
+				<li>If |result| is true, then show the UA context menu</li>
+                </ol>
+			<p class="note">
+			To handle a context menu triggered by the keyboard, call this algorithm with |native| = null and |target| = currently focused element.
+			</p>
+            </li>
+            </ol>
+		
+
+
+
+	    <h4>Mouse Event Order</h4>
+
+		<p>
+            Certain mouse events defined in this specification MUST occur in a set order relative to one another. The following shows the event sequence that MUST occur when a pointing device's cursor is moved over an element:
+        </p>
+        <table class="event-sequence-table">
+     <thead>
+      <tr>
+       <td class="cell-number">#
+       <th>Event Type
+       <th style="text-align:center">Element
+       <th>Notes
+     <tbody>
+      <tr>
+       <td class="cell-number">1
+       <td>{{mousemove}}
+       <td style="text-align:center">
+       <td>
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved into element A...</em>
+      <tr>
+       <td class="cell-number">2
+       <td>{{mouseover}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">3
+       <td>{{mouseenter}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">4
+       <td>{{mousemove}}
+       <td style="text-align:center">A
+       <td>Multiple {{mousemove}} events
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved out of element A...</em>
+      <tr>
+       <td class="cell-number">5
+       <td>{{mouseout}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">6
+       <td>{{mouseleave}}
+       <td style="text-align:center">A
+       <td>
+    </table>
+		<p>
+            When a pointing device is moved into an element <em>A</em>, and then into a nested element <em>B</em> and then back out again, the following sequence of events MUST occur:
+        </p>
+
+   <table class="event-sequence-table">
+     <thead>
+      <tr>
+       <td class="cell-number">
+       <th>Event Type
+       <th style="text-align:center">Element
+       <th>Notes
+     <tbody>
+      <tr>
+       <td class="cell-number">1
+       <td>{{mousemove}}</a>
+       <td style="text-align:center">
+       <td>
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved into element A...</em>
+      <tr>
+       <td class="cell-number">2
+       <td>{{mouseover}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">3
+       <td>{{mouseenter}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">4
+       <td>{{mousemove}}
+       <td style="text-align:center">A
+       <td>Multiple {{mousemove}} events
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved into nested element B...</em>
+      <tr>
+       <td class="cell-number">5
+       <td>{{mouseout}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">6
+       <td>{{mouseover}}
+       <td style="text-align:center">B
+       <td>
+      <tr>
+       <td class="cell-number">7
+       <td>{{mouseenter}}
+       <td style="text-align:center">B
+       <td>
+      <tr>
+       <td class="cell-number">8
+       <td>{{mousemove}}
+       <td style="text-align:center">B
+       <td>Multiple {{mousemove}} events
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved from element B into A...</em>
+      <tr>
+       <td class="cell-number">9
+       <td>{{mouseout}}
+       <td style="text-align:center">B
+       <td>
+      <tr>
+       <td class="cell-number">10
+       <td>{{mouseleave}}
+       <td style="text-align:center">B
+       <td>
+      <tr>
+       <td class="cell-number">11
+       <td>{{mouseover}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">12
+       <td>{{mousemove}}
+       <td style="text-align:center">A
+       <td>Multiple {{mousemove}} events
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved out of element A...</em>
+      <tr>
+       <td class="cell-number">13
+       <td>{{mouseout}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">14
+       <td>{{mouseleave}}
+       <td style="text-align:center">A
+       <td>
+    </table>
+
+		<p>
+            Sometimes elements can be visually overlapped using CSS. In the following example, three elements labeled A, B, and C all have the same dimensions and absolute position on a web page. Element C is a child of B, and B is a child of A in the DOM:
+        </p>
+		<figure id="figure-mouse-event-stacked-elements">
+			<img src='images/stacked-event-mouse-dispatch.svg' height="250" alt="Graphical representation of three stacked elements all on top of each other. The bottom element is labeled A and the top element is C">
+			<figcaption>Graphical representation of three stacked elements all on top of each other, with the pointing device moving over the stack.</figcaption>
+		</figure>
+
+		<p>
+            When the pointing device is moved from outside the element stack to the element labeled C and then moved out again, the following series of events MUST occur:
+        </p>
+
+	    <table class="event-sequence-table">
+     <thead>
+      <tr>
+       <td class="cell-number">
+       <th>Event Type
+       <th style="text-align:center">Element
+       <th>Notes
+     <tbody>
+      <tr>
+       <td class="cell-number">1
+       <td>{{mousemove}}
+       <td style="text-align:center">
+       <td>
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved into element C, the topmost element in the stack</em>
+      <tr>
+       <td class="cell-number">2
+       <td>{{mouseover}}
+       <td style="text-align:center">C
+       <td>
+      <tr>
+       <td class="cell-number">3
+       <td>{{mouseenter}}
+       <td style="text-align:center">A
+       <td>
+      <tr>
+       <td class="cell-number">4
+       <td>{{mouseenter}}
+       <td style="text-align:center">B
+       <td>
+      <tr>
+       <td class="cell-number">5
+       <td>{{mouseenter}}
+       <td style="text-align:center">C
+       <td>
+      <tr>
+       <td class="cell-number">6
+       <td>{{mousemove}}
+       <td style="text-align:center">C
+       <td>Multiple {{mousemove}} events
+      <tr>
+       <td class="cell-number">
+       <td>
+       <td style="text-align:center">
+       <td><em>Pointing device is moved out of element C...</em>
+      <tr>
+       <td class="cell-number">7
+       <td>{{mouseout}}
+       <td style="text-align:center">C
+       <td>
+      <tr>
+       <td class="cell-number">8
+       <td>{{mouseleave}}
+       <td style="text-align:center">C
+       <td>
+      <tr>
+       <td class="cell-number">9
+       <td>{{mouseleave}}
+       <td style="text-align:center">B
+       <td>
+      <tr>
+       <td class="cell-number">10
+       <td>{{mouseleave}}
+       <td style="text-align:center">A
+       <td>
+    </table>
+
+		<p class="note">
+		    The {{mouseover}}/{{mouseout}} events are only fired once, while {{mouseenter}}/{{mouseleave}} events are fired three times (once to each element).
+		</p>
+
+		<p>
+            The following is the typical sequence of events when a button associated with a pointing device (e.g., a mouse button or trackpad) is pressed and released over an element:
+        </p>
+
+		 <table class="event-sequence-table">
+     <thead>
+      <tr>
+       <td class="cell-number">
+       <th>Event Type
+       <th>Notes
+     <tbody>
+      <tr>
+       <td class="cell-number">1
+       <td>{{mousedown}}
+       <td>
+      <tr>
+       <td class="cell-number">2
+       <td>{{mousemove}}
+       <td>OPTIONAL, multiple events, some limits
+      <tr>
+       <td class="cell-number">3
+       <td>{{mouseup}}
+       <td>
+      <tr>
+       <td class="cell-number">4
+       <td>{{click}}
+       <td>
+      <tr>
+       <td class="cell-number">5
+       <td>{{mousemove}}
+       <td>OPTIONAL, multiple events, some limits
+      <tr>
+       <td class="cell-number">6
+       <td>{{mousedown}}
+       <td>
+      <tr>
+       <td class="cell-number">7
+       <td>{{mousemove}}</a>
+       <td>OPTIONAL, multiple events, some limits
+      <tr>
+       <td class="cell-number">8
+       <td>{{mouseup}}</a>
+       <td>
+      <tr>
+       <td class="cell-number">9
+       <td>{{click}}
+       <td>
+      <tr>
+       <td class="cell-number">10
+       <td>{{dblclick}}
+       <td>
+    </table>
+
+		<p class="note">
+		The lag time, degree, distance, and number of {{mousemove}} events allowed between the {{mousedown}} and {{mouseup}} events while still firing a {{click}} or {{dblclick}} event will be implementation-, device-, and platform-specific. This tolerance can aid users that have physical disabilities like unsteady hands when these users interact with a pointing device.
+		</p>
+
+		<p>
+            Each implementation will determine the appropriate <a>hysteresis</a>
+		tolerance, but in general SHOULD fire {{click}} and {{dblclick}}
+		events when the event target of the associated {{mousedown}} and
+		{{mouseup}} events is the same element with no {{mouseout}} or
+		{{mouseleave}} events intervening, and SHOULD fire {{click}} and
+		{{dblclick}} events on the nearest common inclusive ancestor when the
+		associated {{mousedown}} and {{mouseup}} event targets are
+		different.
+        </p>
+
+		<p class="example">
+		If a {{mousedown}} event was targeted at an HTML document's <a data-lt="the body element">body
+		element</a>, and the corresponding {{mouseup}} event was targeted at
+		the <a>document element</a>, then the {{click}} event will be dispatched
+		to the <a>document element</a>, since it is the nearest common inclusive
+		ancestor.
+		</p>
+
+		<p>If the [=Event/target=] (e.g. the target element) is removed from the
+		DOM during the mouse events sequence, the remaining events of the
+		sequence MUST NOT be fired on that element.
+
+		<p class="example">
+		If the target element is removed from the DOM as the result of a
+		{{mousedown}} event, no events for that element will be dispatched
+		for {{mouseup}}, {{click}}, or {{dblclick}}, nor any default
+		activation events. However, the {{mouseup}} event will still be
+		dispatched on the element that is exposed to the mouse after the removal
+		of the initial target element. Similarly, if the target element is
+		removed from the DOM during the dispatch of a {{mouseup}} event, the
+		{{click}} and subsequent events will not be dispatched.
+		</p>
+
+	<h4>Mouse Event Types</h4>
+
+		The Mouse event types are listed below. In the case of nested elements,
+		mouse event types are always targeted at the most deeply nested element.
+		Ancestors of the targeted element MAY use bubbling to obtain
+		notification of mouse events which occur within its descendent elements.
+
+	<h5><dfn>auxclick</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>auxclick</code></strong>
+      <tr>
+       <th>Interface
+       <td>{{PointerEvent}}
+      <tr>
+       <th>Sync / Async
+       <td>Sync
+      <tr>
+       <th>Bubbles
+       <td>Yes
+      <tr>
+       <th>Trusted Targets
+       <td><code>Element</code>       <tr>
+       <th>Cancelable
+       <td>Yes
+      <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
+       <th>Default action
+       <td>Varies
+      <tr>
+       <th>Context<br> (trusted events)
+       <td>
+        <ul>
+         <li>{{Event.target}} : [=topmost event target=]
+         <li>{{UIEvent.view}} : {{Window}}
+         <li>{{UIEvent.detail}} : indicates the [=current click count=]; the attribute value MUST be <code>1</code> when the user begins this action and increments by <code>1</code> for each click.
+         <li>{{MouseEvent.screenX}} : value based on the pointer position on the screen
+         <li>{{MouseEvent.screenY}} : value based on the pointer position on the screen
+         <li>{{MouseEvent.clientX}} : value based on the pointer position within the viewport
+         <li>{{MouseEvent.clientY}} : value based on the pointer position within the viewport
+         <li>{{MouseEvent.layerX}} : value based on the pointer position within the containing element
+         <li>{{MouseEvent.layerY}} : value based on the pointer position within the containing element
+         <li>{{MouseEvent.altKey}} : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.ctrlKey}} : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.shiftKey}} : <code>true</code> if <code class="keycap">Shift</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.metaKey}} : <code>true</code> if <code class="keycap">Meta</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.button}} : value based on current button pressed
+         <li>{{MouseEvent.buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed
+         <li>{{MouseEvent.relatedTarget}} : <code>null</code>          <li>For {{PointerEvent}} specific attributes, see the [[PointerEvents]] spec.
+        </ul>
+    </table>
+            <p>
+			The {{auxclick}} event type MUST be dispatched on the <a>topmost
+			event target</a> indicated by the pointer, when the user presses
+			down and releases the non-primary pointer button, or otherwise activates
+			the pointer in a manner that simulates such an action. The actuation
+			method of the mouse button depends upon the pointer device and the
+			environment configuration, e.g., it MAY depend on the screen
+			location or the delay between the press and release of the pointing
+			device button.
+
+			<p>
+            The {{auxclick}} event should only be fired for the non-primary pointer
+			buttons (i.e., when {{MouseEvent/button}} value is not <code>0</code>,
+			{{MouseEvent/buttons}} value is greater than <code>1</code>). The primary button
+			(like the left button on a standard mouse) MUST NOT fire
+			{{auxclick}} events. See {{click}} for a corresponding event that
+			is associated with the primary button.
+
+			<p>
+            The {{auxclick}} event MAY be preceded by the {{mousedown}} and
+			{{mouseup}} events on the same element, disregarding changes
+			between other node types (e.g., text nodes).  Depending upon the
+			environment configuration, the {{auxclick}} event MAY be dispatched
+			if one or more of the event types {{mouseover}},
+			{{mousemove}}, and {{mouseout}} occur between the press and
+			release of the pointing device button.
+
+			<p>
+            The <a>default action</a> of the {{auxclick}} event type varies
+			based on the [=Event/target=] of the event and the value of the
+			{{MouseEvent/button}} or {{MouseEvent/buttons}} attributes. Typical
+			<a>default actions</a> of the {{auxclick}} event type are as follows:
+
+			<ul><li>
+                If the [=Event/target=] has associated activation behavior,
+				the <a>default action</a> MUST be to execute that activation
+				behavior.
+            </li></ul>
+			<pre class="example" title="Receiving and handling auxclick for the middle">
+<code>myLink.addEventListener("auxclick", function(e) {
+  if (e.button === 1) {
+    // This would prevent the default behavior which is for example
+    // opening a new tab when middle clicking on a link.
+    e.preventDefault();
+    // Do something else to handle middle button click like taking
+    // care of opening link or non-link buttons in new tabs in a way
+    // that fits the app. Other actions like closing a tab in a tab-strip
+    // which should be done on the click action can be done here too.
+  }
+});
+</code></pre>
+			<p class="note">
+			In the case of right button, the {{auxclick}} event is dispatched after
+			any EVENT{contextmenu} event. Note that some user agents swallow all input
+			events while a context menu is being displayed, so auxclick may not be
+			available to applications in such scenarios.
+			See <a href="#example-auxclick-right"></a> for more clarification.
+			</p>
+
+			<pre id="example-auxclick-right" class="example" title="Receiving and handling auxclick for the right button">
+<code>myDiv.addEventListener("contextmenu", function(e) {
+  // This call makes sure no context menu is shown
+  // to interfere with page receiving the events.
+  e.preventDefault();
+});
+myDiv.addEventListener("auxclick", function(e) {
+  if (e.button === 2) {
+    // Do something else to handle right button click like opening a
+    // customized context menu inside the app.
+  }
+});
+</code></pre>
+
+		<h5><dfn>click</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>click</code></strong>
+      <tr>
+       <th>Interface
+       <td>{{PointerEvent}}
+      <tr>
+       <th>Sync / Async
+       <td>Sync
+      <tr>
+       <th>Bubbles
+       <td>Yes
+      <tr>
+       <th>Trusted Targets
+       <td><code>Element</code>       <tr>
+       <th>Cancelable
+       <td>Yes
+      <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
+       <th>Default action
+       <td>Varies
+      <tr>
+       <th>Context<br> (trusted events)
+       <td>
+        <ul>
+         <li>{{Event.target}} : [=topmost event target=]
+         <li>{{UIEvent.view}} : {{Window}}
+         <li>{{UIEvent.detail}} : indicates the [=current click count=]; the attribute value MUST be <code>1</code> when the user begins this action and increments by <code>1</code> for each click.
+         <li>{{MouseEvent.screenX}} : value based on the pointer position on the screen
+         <li>{{MouseEvent.screenY}} : value based on the pointer position on the screen
+         <li>{{MouseEvent.clientX}} : value based on the pointer position within the viewport
+         <li>{{MouseEvent.clientY}} : value based on the pointer position within the viewport
+         <li>{{MouseEvent.layerX}} : value based on the pointer position within the containing element
+         <li>{{MouseEvent.layerY}} : value based on the pointer position within the containing element
+         <li>{{MouseEvent.altKey}} : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.ctrlKey}} : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.shiftKey}} : <code>true</code> if <code class="keycap">Shift</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.metaKey}} : <code>true</code> if <code class="keycap">Meta</code> modifier was active, otherwise <code>false</code>          <li>{{MouseEvent.button}} : value based on current button pressed
+         <li>{{MouseEvent.buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed
+         <li>{{MouseEvent.relatedTarget}} : <code>null</code>          <li>For {{PointerEvent}} specific attributes, see the [PointerEvents] spec.
+        </ul>
+    </table>
+            <p>
+			The {{click}} event type MUST be dispatched on the <a>topmost
+			event target</a> indicated by the pointer, when the user presses
+			down and releases the primary pointer button, or otherwise activates
+			the pointer in a manner that simulates such an action. The actuation
+			method of the mouse button depends upon the pointer device and the
+			environment configuration, e.g., it MAY depend on the screen
+			location or the delay between the press and release of the pointing
+			device button.
+
+			<p>
+			The {{click}} event should only be fired for the primary pointer
+			button (i.e., when {{MouseEvent/button}} value is <code>0</code>,
+			{{MouseEvent/buttons}} value is <code>1</code>). Secondary buttons
+			(like the middle or right button on a standard mouse) MUST NOT fire
+			{{click}} events. See {{auxclick}} for a corresponding event that
+			is associated with the non-primary buttons.
+
+			<p>
+			The {{click}} event MAY be preceded by the {{mousedown}} and
+			{{mouseup}} events on the same element, disregarding changes
+			between other node types (e.g., text nodes).  Depending upon the
+			environment configuration, the {{click}} event MAY be dispatched
+			if one or more of the event types {{mouseover}},
+			{{mousemove}}, and {{mouseout}} occur between the press and
+			release of the pointing device button.  The {{click}} event MAY
+			also be followed by the {{dblclick}} event.
+
+			<p class="example">
+			If a user mouses down on a text node child of a
+			<code>&lt;p&gt;</code> element which has been styled with a large
+			line-height, shifts the mouse slightly such that it is no longer
+			over an area containing text but is still within the containing
+			block of that <code>&lt;p&gt;</code> element (i.e., the pointer is
+			between lines of the same text block, but not over the text node per
+			se), then subsequently mouses up, this will likely still trigger a
+			{{click}} event (if it falls within the normal temporal
+			<a>hysteresis</a> for a {{click}}), since the user has stayed
+			within the scope of the same element. Note that user-agent-generated
+			mouse events are not dispatched on text nodes.
+			</p>
+
+			<p>
+			In addition to being associated with pointer devices, the
+			{{click}} event type MUST be dispatched as part of an element
+			activation.
+
+			<p class="note">
+			For maximum accessibility, content authors are encouraged to use the
+			{{click}} event type when defining activation behavior for custom
+			controls, rather than other pointing-device event types such as
+			{{mousedown}} or {{mouseup}}, which are more device-specific.
+			Though the {{click}} event type has its origins in pointer
+			devices (e.g., a mouse), subsequent implementation enhancements have
+			extended it beyond that association, and it can be considered a
+			device-independent event type for element activation.
+			</p>
+
+			<p>
+			The <a>default action</a> of the {{click}} event type varies
+			based on the [=Event/target=] of the event and the value of the
+			{{MouseEvent/button}} or {{MouseEvent/buttons}} attributes. Typical
+			<a>default actions</a> of the {{click}} event type are as follows:
+
+		    <ul>
+				<li>If the [=Event/target=] has associated activation behavior,
+				the <a>default action</a> MUST be to execute that activation
+				behavior.</li>
+				<li>If the [=Event/target=] is focusable, the <a>default
+				action</a> MUST be to give that element document focus.</li>
+			</ul>
+
+		<h5><dfn>contextmenu</dfn></h5>
+
+	<table class="event-definition">
+    <tbody>
+      <tr>
+        <tr><th>Type</th>
+	    <td><strong><code>contextmenu</code></strong></td>
+		<tr><th>Interface</th>
+		<td>{{PointerEvent}}</td>
+		<tr><th>Sync / Async</th>
+		<td>Sync</td>
+		<tr><th>Bubbles</th>
+		<td>Yes</td>
+		<tr><th>Trusted Targets</th>
+		<td><code>Element</code></td>
+		<tr><th>Cancelable</th>
+		<td>Yes</td>
+		<tr><th>Composed</th>
+		<td>Yes</td>
+		<tr><th>Default action</th>
+		<td>Invoke a context menu if supported.</td>
+		<tr><th>Context<br>(trusted events)</th>
+	    <td><ul>
+			<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+			<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+			<li>{{UIEvent}}.{{UIEvent/detail}} : 0</li>
+			<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on the screen</li>
+			<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on the screen</li>
+			<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position within the viewport</li>
+			<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position within the viewport</li>
+			<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position within the containing element</li>
+			<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position within the containing element</li>
+			<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+			<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+			<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code>modifier was active, otherwise <code>false</code></li>
+			<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code>  modifier was active, otherwise <code>false</code></li>
+			<li>{{MouseEvent}}.{{MouseEvent/button}} : value based on current button pressed</li>
+			<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+			<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : <code>null</code></li>
+			</ul>
+		</td></tr>
+	</table>
+			<p>
+			A <a data-cite="infra">user agent</a> MUST dispatch this event before invoking a context menu.
+
+			<p>
+			When the {{contextmenu}} event is triggered by right mouse button, the
+			{{contextmenu}} event MUST be dispatched after the {{mousedown}} event.
+
+			<p class="note">
+			Depending on the platform, the {{contextmenu}} event may be dispatched
+			before or after the {{mouseup}} event.
+			</p>
+
+		<h5><dfn>dblclick</dfn></h5>
+
+<table class="event-definition">
+    <tbody>
+    <tr>
+    	<th>Type</th>
+    	<td><strong><code>dblclick</code></strong></td>
+	</tr>
+	<tr>
+		<th>Interface</th>
+		<td>{{MouseEvent}}</td>
+	</tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td>
+	</tr>
+	<tr>
+		<th>Bubbles</th><td>Yes</td>
+	</tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td>
+	</tr>
+	<tr>
+		<th>Cancelable</th><td>Yes</td>
+	</tr>
+	<tr>
+		<th>Composed</th><td>Yes</td>
+	</tr>
+	<tr>
+		<th>Default action</th><td>None</td>
+	</tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : indicates the <a href="#current-click-count">current click count</a></li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : value based on current button pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : <code>null</code></li>
+			</ul></td></tr></table>
+
+			<p>
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when the primary button
+			of a pointing device is clicked twice over an element. The
+			definition of a double click depends on the environment
+			configuration, except that the event target MUST be the same between
+			{{mousedown}}, {{mouseup}}, and {{dblclick}}. This event
+			type MUST be dispatched after the event type {{click}} if a click
+			and double click occur simultaneously, and after the event type
+			{{mouseup}} otherwise.
+
+			<p>
+			As with the {{click}} event, the {{dblclick}} event should
+			only be fired for the primary pointer button. Secondary buttons MUST
+			NOT fire {{dblclick}} events.
+
+			<p class="note">
+			Canceling the {{click}} event does not affect the firing of a
+			{{dblclick}} event.
+			</p>
+
+			As with the {{click}} event type, the <a>default action</a> of
+			the {{dblclick}} event type varies based on the [=Event/target=] of the event and the value of the {{MouseEvent/button}}
+			or {{MouseEvent/buttons}} attributes. The typical
+			<a>default actions</a> of the {{dblclick}} event type match those
+			of the {{click}} event type.
+
+		<h5><dfn>mousedown</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>mousedown</code></strong>
+		</tr>
+	<tr>
+		<th>Interface</th><td>{{MouseEvent}}</td></tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td></tr>
+	<tr>
+		<th>Bubbles</th><td>Yes</td></tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td></tr>
+	<tr>
+		<th>Cancelable</th><td>Yes</td></tr>
+	<tr>
+		<th>Composed</th><td>Yes</td></tr>
+	<tr>
+		<th>Default action</th><td>Varies: Start a drag/drop operation; start a text selection; start a scroll/pan
+		 interaction (in combination with the middle mouse button, if supported)</td></tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : indicates the <a href="#current-click-count">current click count</a> incremented by one. For example, if no click happened before the {{mousedown}}, {{UIEvent/detail}} will contain the value <code>1</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : value based on current button pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : <code>null</code></li>
+			</ul></td></tr></table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
+			button is pressed over an element.
+
+			<p class="note">
+			Many implementations use the {{mousedown}} event to begin a
+			variety of contextually dependent <a>default actions</a>. These
+			default actions can be prevented if this event is canceled. Some of
+			these default actions could include: beginning a drag/drop
+			interaction with an image or link, starting text selection, etc.
+			Additionally, some implementations provide a mouse-driven panning
+			feature that is activated when the middle mouse button is pressed at
+			the time the {{mousedown}} event is dispatched.
+			</p>
+
+		<h5><dfn>mouseenter</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>mouseenter</code></strong>
+		</tr>
+	<tr>
+		<th>Interface</th><td>{{MouseEvent}}</td></tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td></tr>
+	<tr>
+		<th>Bubbles</th><td>No</td></tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td></tr>
+	<tr>
+		<th>Cancelable</th><td>No</td></tr>
+	<tr>
+		<th>Composed</th><td>No</td></tr>
+	<tr>
+		<th>Default action</th><td>None</td></tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : indicates the [=Event/target=]  |
+		     a pointing device is exiting, if any.</li>
+			</ul></td></tr></table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
+			is moved onto the boundaries of an element or one of its descendent
+			elements.  A <a data-cite="infra">user agent</a> MUST also dispatch this event when the
+			element or one of its descendants moves to be underneath the primary
+			pointing device. This event type is similar to {{mouseover}}, but
+			differs in that it does not bubble, and MUST NOT be dispatched when
+			the pointer device moves from an element onto the boundaries of one
+			of its descendent elements.
+
+			<p class="note">
+			There are similarities between this event type and the CSS
+			<a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes"
+			title="Selectors"><code>:hover</code> pseudo-class</a> [[CSS2]].
+			See also the {{mouseleave}} event type.
+			</p>
+
+		<h5><dfn>mouseleave</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>mouseleave</code></strong>
+		</tr>
+	<tr>
+		<th>Interface</th><td>{{MouseEvent}}</td></tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td></tr>
+	<tr>
+		<th>Bubbles</th><td>No</td></tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td></tr>
+	<tr>
+		<th>Cancelable</th><td>No</td></tr>
+	<tr>
+		<th>Composed</th><td>No</td></tr>
+	<tr>
+		<th>Default action</th><td>None</td></tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : indicates the [=Event/target=]  |
+		     a pointing device is exiting, if any.</li>
+			</ul></td></tr></table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
+			is moved off of the boundaries of an element and all of its
+			descendent elements.  A <a data-cite="infra">user agent</a> MUST also dispatch this event
+			when the element or one of its descendants moves to be no longer underneath
+			the primary pointing device. This event type is similar to {{mouseout}},
+			but differs in that does not bubble, and that it MUST NOT be
+			dispatched until the pointing device has left the boundaries of the
+			element and the boundaries of all of its children.
+
+			<p class="note">
+			There are similarities between this event type and the CSS
+			<a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes"
+			title="Selectors"><code>:hover</code> pseudo-class</a> [[CSS2]].
+			See also the {{mouseenter}} event type.
+			</p>
+
+		<h5><dfn>mousemove</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>mousemove</code></strong>
+		</tr>
+	<tr>
+		<th>Interface</th><td>{{MouseEvent}}</td></tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td></tr>
+	<tr>
+		<th>Bubbles</th><td>Yes</td></tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td></tr>
+	<tr>
+		<th>Cancelable</th><td>Yes</td></tr>
+	<tr>
+		<th>Composed</th><td>Yes</td></tr>
+	<tr>
+		<th>Default action</th><td>None</td></tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : <code>null</code></li>
+			</ul></td></tr></table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
+			is moved while it is over an element.  The frequency rate of events
+			while the pointing device is moved is implementation-, device-, and
+			platform-specific, but multiple consecutive {{mousemove}} events
+			SHOULD be fired for sustained pointer-device movement, rather than a
+			single event for each instance of mouse movement.  Implementations
+			are encouraged to determine the optimal frequency rate to balance
+			responsiveness with performance.
+
+			<p class="note">
+			In some implementation environments, such as a browser,
+			{{mousemove}} events can continue to fire if the user began a
+			drag operation (e.g., a mouse button is pressed) and the pointing
+			device has left the boundary of the user agent.
+			</p>
+
+			<p class="note" id="mousemove-now-cancelable">
+			This event was formerly specified to be non-cancelable in DOM Level
+			2 Events, but was changed to reflect existing interoperability between
+			user agents.
+			</p>
+
+		<h5><dfn>mouseout</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>mouseout</code></strong>
+		</tr>
+	<tr>
+		<th>Interface</th><td>{{MouseEvent}}</td></tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td></tr>
+	<tr>
+		<th>Bubbles</th><td>Yes</td></tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td></tr>
+	<tr>
+		<th>Cancelable</th><td>Yes</td></tr>
+	<tr>
+		<th>Composed</th><td>Yes</td></tr>
+	<tr>
+		<th>Default action</th><td>None</td></tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : indicates the [=Event/target=]  |
+		     a pointing device is entering, if any.</li>
+			</ul></td></tr></table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
+			is moved off of the boundaries of an element or when the element is
+			moved to be no longer underneath the primary pointing device.
+			This event type is similar to {{mouseleave}}, but differs in that
+			does bubble, and that it MUST be dispatched when the pointer device
+			moves from an element onto the boundaries of one of its descendent elements.
+
+			<p class="note">
+			See also the {{mouseover}} event type.
+			</p>
+
+		<h5><dfn>mouseover</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>mouseover</code></strong>
+		</tr>
+	<tr>
+		<th>Interface</th><td>{{MouseEvent}}</td></tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td></tr>
+	<tr>
+		<th>Bubbles</th><td>Yes</td></tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td></tr>
+	<tr>
+		<th>Cancelable</th><td>Yes</td></tr>
+	<tr>
+		<th>Composed</th><td>Yes</td></tr>
+	<tr>
+		<th>Default action</th><td>None</td></tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : <code>0</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : indicates the [=Event/target=]  |
+		     a pointing device is entering, if any.</li>
+			</ul></td></tr></table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
+			is moved onto the boundaries of an element or when the element is
+			moved to be underneath the primary pointing device.
+			This event type is similar to {{mouseenter}}, but differs in
+			that it bubbles, and that it MUST be dispatched when the pointer device moves onto the
+			boundaries of an element whose ancestor element is the [=Event/target=] for the same <a>event listener</a> instance.
+
+			<p class="note">
+			See also the {{mouseout}} event type.
+			</p>
+
+		        <h5><dfn>mouseup</dfn></h5>
+
+<table class="event-definition">
+     <tbody>
+      <tr>
+       <th>Type
+       <td><strong><code>mouseup</code></strong>
+		</tr>
+	<tr>
+		<th>Interface</th><td>{{MouseEvent}}</td></tr>
+	<tr>
+		<th>Sync / Async</th><td>Sync</td></tr>
+	<tr>
+		<th>Bubbles</th><td>Yes</td></tr>
+	<tr>
+		<th>Trusted Targets</th><td><code>Element</code></td></tr>
+	<tr>
+		<th>Cancelable</th><td>Yes</td></tr>
+	<tr>
+		<th>Composed</th><td>Yes</td></tr>
+	<tr>
+		<th>Default action</th><td>None</td></tr>
+	<tr>
+		<th>Context<br> (trusted events)</th>
+		<td>
+			<ul>
+<li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
+<li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : indicates the
+		     <a href="#current-click-count">current click count</a> incremented by one.</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
+the screen</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientX}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/clientY}} : value based on the pointer position
+within the viewport</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerX}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/layerY}} : value based on the pointer position
+within the containing element</li>
+<li>{{MouseEvent}}.{{MouseEvent/altKey}} : <code>true</code> if <code class='keycap'>Alt</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/ctrlKey}} : <code>true</code> if <code class='keycap'>Control</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/shiftKey}} : <code>true</code> if <code class='keycap'>Shift</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/metaKey}} : <code>true</code> if <code class='keycap'>Meta</code> modifier was active, otherwise <code>false</code></li>
+<li>{{MouseEvent}}.{{MouseEvent/button}} : value based on current button pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/buttons}} : value based on all buttons currently depressed, <code>0</code> if no buttons pressed</li>
+<li>{{MouseEvent}}.{{MouseEvent/relatedTarget}} : <code>null</code></li>
+			</ul></td></tr></table>
+
+			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
+			button is released over an element.
+
+			<p class="note">
+			In some implementation environments, such as a browser, a
+			{{mouseup}} event can be dispatched even if the pointing device
+			has left the boundary of the user agent, e.g., if the user began a
+			drag operation with a mouse button pressed.
+			</p>
+
+
     <section>
         <h1>Pointer Events and interfaces</h1>
         <section>
@@ -270,19 +2529,19 @@ interface PointerEvent : MouseEvent {
                 <dl data-dfn-for="PointerEvent" data-link-for="PointerEvent">
                     <dt><dfn>pointerId</dfn></dt>
                         <dd>
-                            <p>A unique identifier for the pointer causing the event. [=user agents=] MAY reserve a generic {{pointerId}} value of <code>0</code> or <code>1</code> for the primary mouse pointer. The {{pointerId}} value of <code>-1</code> MUST be reserved and used to indicate events that were generated by something other than a pointing device. For any other pointers, user agents are free to implement different strategies and approaches in how they assign a {{pointerId}} value. However, all <a>active pointers</a> in the [=top-level browsing context=] (as defined by [[HTML]]) must be unique, and the identifier MUST NOT be influenced by any other top-level browsing context (i.e. one top-level browsing context cannot assume that the {{pointerId}} of a pointer will be the same when the pointer moves outside of the browsing context and into another top-level browsing context).</p>
-                            <p>The [=user agent=] MAY recycle previously retired values for {{pointerId}} from previous active pointers, or it MAY always reuse the same {{pointerId}} for a particular pointing device (for instance, to uniquely identify particular pen/stylus inputs from a specific user in a multi-user collaborative application). However, in the latter case, to minimize the chance of fingerprinting and tracking across different pages or domains, the {{pointerId}} MUST only be associated explicitly with that particular pointing device for the lifetime of the page / session, and a new randomized {{pointerId}} MUST be chosen the next time that particular pointing device is used again in a new session.</p>
+                            <p>A unique identifier for the pointer causing the event.  <a data-cite="infra">user agents</a> MAY reserve a generic {{pointerId}} value of <code>0</code> or <code>1</code> for the primary mouse pointer. The {{pointerId}} value of <code>-1</code> MUST be reserved and used to indicate events that were generated by something other than a pointing device. For any other pointers, user agents are free to implement different strategies and approaches in how they assign a {{pointerId}} value. However, all <a>active pointers</a> in the [=top-level browsing context=] (as defined by [[HTML]]) must be unique, and the identifier MUST NOT be influenced by any other top-level browsing context (i.e. one top-level browsing context cannot assume that the {{pointerId}} of a pointer will be the same when the pointer moves outside of the browsing context and into another top-level browsing context).</p>
+                            <p>The  <a data-cite="infra">user agent</a> MAY recycle previously retired values for {{pointerId}} from previous active pointers, or it MAY always reuse the same {{pointerId}} for a particular pointing device (for instance, to uniquely identify particular pen/stylus inputs from a specific user in a multi-user collaborative application). However, in the latter case, to minimize the chance of fingerprinting and tracking across different pages or domains, the {{pointerId}} MUST only be associated explicitly with that particular pointing device for the lifetime of the page / session, and a new randomized {{pointerId}} MUST be chosen the next time that particular pointing device is used again in a new session.</p>
                             <div class="note">
                                 <p>The {{pointerId}} selection algorithm is implementation specific. Authors cannot assume values convey any particular meaning other than an identifier for the pointer that is unique from all other active pointers. As an example, user agents may simply assign a number, starting from <code>0</code>, to any active pointers, in the order that they become active — but these values are not guaranteed to be monotonically increasing. As the reuse of the same {{pointerId}} for a particular pointing device is left up to individual implementations, authors are strongly discouraged from relying on it, and to refer to {{persistentDeviceId}} instead.</p>
                             </div>
                         </dd>
                     <dt><dfn>width</dfn></dt>
                         <dd>
-                            <p>The width (magnitude on the X axis), in CSS pixels (see [[CSS21]]), of the <a>contact geometry</a> of the pointer. This value MAY be updated on each event for a given pointer. For inputs that typically lack contact geometry (such as a traditional mouse), and in cases where the actual geometry of the input is not detected by the hardware, the [=user agent=] MUST return a default value of <code>1</code>.</p>
+                            <p>The width (magnitude on the X axis), in CSS pixels (see [[CSS21]]), of the <a>contact geometry</a> of the pointer. This value MAY be updated on each event for a given pointer. For inputs that typically lack contact geometry (such as a traditional mouse), and in cases where the actual geometry of the input is not detected by the hardware, the  <a data-cite="infra">user agent</a> MUST return a default value of <code>1</code>.</p>
                         </dd>
                     <dt><dfn>height</dfn></dt>
                         <dd>
-                            <p>The height (magnitude on the Y axis), in CSS pixels (see [[CSS21]]), of the <a>contact geometry</a> of the pointer. This value MAY be updated on each event for a given pointer. For inputs that typically lack contact geometry (such as a traditional mouse), and in cases where the actual geometry of the input is not detected by the hardware, the [=user agent=] MUST return a default value of <code>1</code>.</p>
+                            <p>The height (magnitude on the Y axis), in CSS pixels (see [[CSS21]]), of the <a>contact geometry</a> of the pointer. This value MAY be updated on each event for a given pointer. For inputs that typically lack contact geometry (such as a traditional mouse), and in cases where the actual geometry of the input is not detected by the hardware, the  <a data-cite="infra">user agent</a> MUST return a default value of <code>1</code>.</p>
                         </dd>
                     <dt><dfn>pressure</dfn></dt>
                         <dd>
@@ -439,7 +2698,7 @@ interface PointerEvent : MouseEvent {
                 <div class="note">Authors who desire single-pointer interaction can achieve this by ignoring non-primary pointers (however, see the note below on <a href="#multiple-primary-pointers">multiple primary pointers</a>).</div>
                 <div class="note" id="multiple-primary-pointers">When two or more pointer device types are being used concurrently, multiple pointers (one for each <code>pointerType</code>) are considered primary. For example, a touch contact and a mouse cursor moved simultaneously will produce pointers that are both considered primary.</div>
                 <div class="note">Some devices, operating systems and user agents may ignore the concurrent use of more than one type of pointer input to avoid accidental interactions. For instance, devices that support both touch and pen interactions may ignore touch inputs while the pen is actively being used, to allow users to rest their hand on the touchscreen while using the pen (a feature commonly referred to as "palm rejection"). Currently, it is not possible for authors to suppress this behavior.</div>
-                <div class="note">In some cases, it is possible for the user agent to fire pointer events in which no pointer is marked as a primary pointer. For instance, when there are multiple active pointers of a particular type, like a multi-touch interaction, and the primary pointer is removed (e.g. it leaves the screen), there may end up being no primary pointers. Also on platforms where the primary pointer is determined using all active pointers of the same type on the device (including those targeted at an application other than the user agent), if the first (primary) pointer is outside of the user agent and other (non-primary) pointers targeted inside the user agent, then the [=user agent=] MAY fire pointer events for the other pointers with a value of <code>false</code> for <code>isPrimary</code>.</div>
+                <div class="note">In some cases, it is possible for the user agent to fire pointer events in which no pointer is marked as a primary pointer. For instance, when there are multiple active pointers of a particular type, like a multi-touch interaction, and the primary pointer is removed (e.g. it leaves the screen), there may end up being no primary pointers. Also on platforms where the primary pointer is determined using all active pointers of the same type on the device (including those targeted at an application other than the user agent), if the first (primary) pointer is outside of the user agent and other (non-primary) pointers targeted inside the user agent, then the  <a data-cite="infra">user agent</a> MAY fire pointer events for the other pointers with a value of <code>false</code> for <code>isPrimary</code>.</div>
                 <div class="note" id="multiple-mouse-inputs">Current operating systems and user agents don't usually have a concept of multiple mouse inputs. When more than one mouse device is present (for instance, on a laptop with both a trackpad and an external mouse), all mouse devices are generally treated as a single device — movements on any of the devices are translated to movement of a single mouse pointer, and there is no distinction between button presses on different mouse devices. For this reason, there will usually only be a single mouse pointer, and that pointer will be primary.</div>
             </section>
 
@@ -461,7 +2720,7 @@ interface PointerEvent : MouseEvent {
                 <p>If the event is {{pointerdown}}, the associated device is a direct manipulation device, and the target is an {{Element}},
                     then <a>set pointer capture</a> for this {{PointerEvent/pointerId}} to the target element as described in <a>implicit pointer capture</a>.</p>
 
-                <p>Before firing this event, the [=user agent=] SHOULD treat the target as if the pointing device has moved over it from the |previousTarget| for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]]. If the |needsOverEvent| flag is set, a {{pointerover}} event is needed even if the target element is the same.</p>
+                <p>Before firing this event, the  <a data-cite="infra">user agent</a> SHOULD treat the target as if the pointing device has moved over it from the |previousTarget| for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]]. If the |needsOverEvent| flag is set, a {{pointerover}} event is needed even if the target element is the same.</p>
 
                 <p>Fire the event to the determined target.</p>
 
@@ -565,7 +2824,7 @@ interface PointerEvent : MouseEvent {
 
                 <section>
                     <h4><dfn>Process pending pointer capture</dfn></h4>
-                    <p>The [=user agent=] MUST run the following steps when <a>implicitly releasing pointer capture</a> as well as when firing Pointer Events that are not {{gotpointercapture}} or {{lostpointercapture}}.</p>
+                    <p>The  <a data-cite="infra">user agent</a> MUST run the following steps when <a>implicitly releasing pointer capture</a> as well as when firing Pointer Events that are not {{gotpointercapture}} or {{lostpointercapture}}.</p>
                     <ol>
                         <li>If the <a>pointer capture target override</a> for this pointer is set and is not equal to the <a>pending pointer capture target override</a>, then fire a pointer event named {{lostpointercapture}} at the <a>pointer capture target override</a> node.
                         </li>
@@ -581,7 +2840,7 @@ interface PointerEvent : MouseEvent {
 
                 <section>
                     <h4>Suppressing a pointer event stream</h4>
-                    <p>The [=user agent=] MUST <dfn>suppress a pointer event stream</dfn> when it detects that the web page is unlikely to continue to receive pointer events with a specific {{PointerEvent/pointerId}}. Any of the following scenarios satisfy this condition (there MAY be additional scenarios):</p>
+                    <p>The  <a data-cite="infra">user agent</a> MUST <dfn>suppress a pointer event stream</dfn> when it detects that the web page is unlikely to continue to receive pointer events with a specific {{PointerEvent/pointerId}}. Any of the following scenarios satisfy this condition (there MAY be additional scenarios):</p>
                     <ul>
                         <li>The user agent has opened a modal dialog or menu.</li>
                         <li>A pointer input device is physically disconnected, or a hoverable pointer input device (e.g. a hoverable pen/stylus) has left the hover range detectable by the digitizer.</li>
@@ -592,7 +2851,7 @@ interface PointerEvent : MouseEvent {
                             for the pointer that caused the drag operation.</li>
                     </ul>
                     <div class="note">
-                        <p>Other scenarios in which the [=user agent=] MAY <a>suppress a pointer event stream</a> include:</p>
+                        <p>Other scenarios in which the  <a data-cite="infra">user agent</a> MAY <a>suppress a pointer event stream</a> include:</p>
                         <ul>
                             <li>A device's screen orientation is changed while a pointer is active.</li>
                             <li>The user attempts to interact using more simultaneous pointer inputs than the device supports.</li>
@@ -601,7 +2860,7 @@ interface PointerEvent : MouseEvent {
                         <p>Methods for detecting any of these scenarios are out of scope for this specification.</p>
                     </div>
 
-                    <p>The [=user agent=] MUST run the following steps to <a>suppress a pointer event stream</a>:</p>
+                    <p>The  <a data-cite="infra">user agent</a> MUST run the following steps to <a>suppress a pointer event stream</a>:</p>
                     <ul>
                         <li>Fire a {{pointercancel}} event.</li>
                         <li>Fire a {{pointerout}} event.</li>
@@ -613,7 +2872,7 @@ interface PointerEvent : MouseEvent {
 
             <section>
                 <h3><dfn data-lt="events-from-layout-changes">Boundary events caused by layout changes</dfn></h3>
-                <p>A pointing device that moved relative to the screen surface or underwent some change in any of its properties fires various events as defined in <a>Pointer Event types</a>.  For a stationary pointing device (that neither moved relative to the screen surface nor underwent any change in any properties), the [=user agent=] MUST fire certain boundary events after a layout change that affected the <a>hit test</a> target for the pointer, see {{pointerover}}, {{pointerenter}}, {{pointerout}} and {{pointerleave}} for details.  The [=user agent=] MAY delay the firing of these boundary events because of performance reasons (e.g. to avoid too many hit-tests or layout changes caused by boundary event listeners).</p>
+                <p>A pointing device that moved relative to the screen surface or underwent some change in any of its properties fires various events as defined in <a>Pointer Event types</a>.  For a stationary pointing device (that neither moved relative to the screen surface nor underwent any change in any properties), the  <a data-cite="infra">user agent</a> MUST fire certain boundary events after a layout change that affected the <a>hit test</a> target for the pointer, see {{pointerover}}, {{pointerenter}}, {{pointerout}} and {{pointerleave}} for details.  The  <a data-cite="infra">user agent</a> MAY delay the firing of these boundary events because of performance reasons (e.g. to avoid too many hit-tests or layout changes caused by boundary event listeners).</p>
                 <div class="note">A stationary pointing device (that neither moved relative to the screen surface nor underwent any change in any properties) never fires a {{pointermove}} event.</div>
             </section>
 
@@ -895,7 +3154,7 @@ function tilt2spherical(tiltX, tiltY) {
             <p>In the case of the <a>primary pointer</a>, these events (with the exception of {{gotpointercapture}} and {{lostpointercapture}}) may also fire <a>compatibility mouse events</a>.</p>
             <section>
                 <h3>The <dfn class="export" data-dfn-type="event">pointerover</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerover}} when any of the following occurs:</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointerover}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved into an element.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element to move underneath an uncaptured pointer of a stationary pointing device.</li>
@@ -905,7 +3164,7 @@ function tilt2spherical(tiltX, tiltY) {
 
             <section>
                 <h3>The <dfn class="export" data-dfn-type="event">pointerenter</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerenter}} when any of the following occurs:</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointerenter}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved into an element or one of its descendants.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element or one of its descendants to move underneath an uncaptured pointer of a stationary pointing device.</li>
@@ -917,15 +3176,15 @@ function tilt2spherical(tiltX, tiltY) {
 
             <section>
                 <h3>The <dfn data-dfn-type="event">pointerdown</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerdown}} when a pointer enters the <a>active buttons state</a>. For mouse, this is when the device transitions from no buttons depressed to at least one button depressed. For touch, this is when physical contact is made with the <a>digitizer</a>. For pen, this is when the pen either makes physical contact with the digitizer without any button depressed, or transitions from no buttons depressed to at least one button depressed while hovering.</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointerdown}} when a pointer enters the <a>active buttons state</a>. For mouse, this is when the device transitions from no buttons depressed to at least one button depressed. For touch, this is when physical contact is made with the <a>digitizer</a>. For pen, this is when the pen either makes physical contact with the digitizer without any button depressed, or transitions from no buttons depressed to at least one button depressed while hovering.</p>
                 <div class="note">For mouse (or other multi-button pointer devices), this means {{pointerdown}} and {{pointerup}} are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a>chorded buttons</a> for more information.</div>
-                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the [=user agent=] MUST also <a>fire a pointer event</a> named {{pointerover}} followed by a pointer event named {{pointerenter}} prior to dispatching the {{pointerdown}} event.</p>
+                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the  <a data-cite="infra">user agent</a> MUST also <a>fire a pointer event</a> named {{pointerover}} followed by a pointer event named {{pointerenter}} prior to dispatching the {{pointerdown}} event.</p>
                 <div class="note">Authors can prevent the firing of certain <a>compatibility mouse events</a> by canceling the {{pointerdown}} event (if the <code>isPrimary</code> property is <code>true</code>). This sets the <code>PREVENT MOUSE EVENT</code> flag on the pointer. Note, however, that this does not prevent the <code>mouseover</code>, <code>mouseenter</code>, <code>mouseout</code>, or <code>mouseleave</code> events from firing.</div>
             </section>
 
             <section>
                 <h3>The <dfn data-dfn-type="event">pointermove</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointermove}} when a pointer changes any properties that don't fire
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointermove}} when a pointer changes any properties that don't fire
                 {{pointerdown}} or {{pointerup}} events. This includes any changes to coordinates, pressure, tangential pressure,
                 tilt, twist, contact geometry (<code>width</code> and <code>height</code>) or <a>chorded buttons</a>.</p>
                 <p>User agents MAY delay dispatch of the {{pointermove}} event (for instance, for performance reasons).
@@ -935,7 +3194,7 @@ function tilt2spherical(tiltX, tiltY) {
 
             <section>
                 <h3>The <dfn data-dfn-type="event">pointerrawupdate</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a>
                 named {{pointerrawupdate}}, and only do so within a [=secure context=], when a pointer changes any properties that don't fire
                 <code>pointerdown</code> or <code>pointerup</code> events.  See <code>pointermove</code> event for a list of such properties.</p>
                 <p>In contrast with {{pointermove}}, user agents SHOULD dispatch {{pointerrawupdate}} events as soon as possible
@@ -945,14 +3204,14 @@ function tilt2spherical(tiltX, tiltY) {
                 which is used for finding the <code>target</code> could be different from its coalesced events.</p>
                 <p>Note that if there is already another {{pointerrawupdate}} with the same {{PointerEvent/pointerId}} that hasn't been dispatched
                 in the [=event loop=], the
-                [=user agent=] MAY coalesce the new {{pointerrawupdate}} with that event instead of creating a new [=task=].
+                 <a data-cite="infra">user agent</a> MAY coalesce the new {{pointerrawupdate}} with that event instead of creating a new [=task=].
                 This may cause {{pointerrawupdate}} to have coalesced events, and
                 they will all be delivered as <a>coalesced events</a> of one {{pointerrawupdate}} event as soon as
                 the event is processed in the [=event loop=].
                 See{{PointerEvent/getCoalescedEvents}} for more information.</p>
                 <p>In terms of ordering of {{pointerrawupdate}} and {{pointermove}},
                 if the user agent received an update from the platform that causes both {{pointerrawupdate}} and {{pointermove}} events,
-                then the [=user agent=] MUST dispatch the {{pointerrawupdate}} event before the corresponding {{pointermove}}.</p>
+                then the  <a data-cite="infra">user agent</a> MUST dispatch the {{pointerrawupdate}} event before the corresponding {{pointermove}}.</p>
                 <p>Other than the <code>target</code>, the concatenation of coalesced events lists of all dispatched {{pointerrawupdate}} events
                 since the last {{pointermove}} event is the same as the coalesced events of the next {{pointermove}} event in terms of the other event attributes.
                 The attributes of {{pointerrawupdate}} are mostly the same as {{pointermove}}, with the exception of
@@ -966,22 +3225,22 @@ function tilt2spherical(tiltX, tiltY) {
 
             <section>
                 <h3>The <dfn data-event-type="event">pointerup</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerup}} when a pointer leaves the <a>active buttons state</a>. For mouse, this is when the device transitions from at least one button depressed to no buttons depressed. For touch, this is when physical contact is removed from the <a>digitizer</a>. For pen, this is when the pen is removed from the physical contact with the digitizer while no button is depressed, or transitions from at least one button depressed to no buttons depressed while hovering.</p>
-                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the [=user agent=] MUST also <a>fire a pointer event</a> named {{pointerout}} followed by a pointer event named {{pointerleave}} after dispatching the {{pointerup}} event.</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointerup}} when a pointer leaves the <a>active buttons state</a>. For mouse, this is when the device transitions from at least one button depressed to no buttons depressed. For touch, this is when physical contact is removed from the <a>digitizer</a>. For pen, this is when the pen is removed from the physical contact with the digitizer while no button is depressed, or transitions from at least one button depressed to no buttons depressed while hovering.</p>
+                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the  <a data-cite="infra">user agent</a> MUST also <a>fire a pointer event</a> named {{pointerout}} followed by a pointer event named {{pointerleave}} after dispatching the {{pointerup}} event.</p>
                 <p>All {{pointerup}} events have a <code>pressure</code> value of <code>0</code>.</p>
-                <p>The [=user agent=] MUST also <a>implicitly release the pointer capture</a> if the pointer is currently captured.</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST also <a>implicitly release the pointer capture</a> if the pointer is currently captured.</p>
                 <div class="note">For mouse (or other multi-button pointer devices), this means {{pointerdown}} and {{pointerup}} are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a>chorded buttons</a> for more information.</div>
             </section>
 
             <section>
                 <h3>The <dfn data-dfn-type="event">pointercancel</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointercancel}} when it detects a scenario to <a>suppress a pointer event stream</a>.</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointercancel}} when it detects a scenario to <a>suppress a pointer event stream</a>.</p>
                 <p>The values of the following properties of the {{pointercancel}} event MUST match the values of the last dispatched pointer event with the same {{PointerEvent/pointerId}}: <code>width</code>, <code>height</code>, <code>pressure</code>, <code>tangentialPressure</code>, <code>tiltX</code>, <code>tiltY</code>, <code>twist</code>, <code>altitudeAngle</code>, <code>azimuthAngle</code>, <code>pointerType</code>, <code>isPrimary</code>, and the coordinates inherited from [[UIEVENTS]]. The <code>coalescedEvents</code> and <code>predictedEvents</code> lists in the {{pointercancel}} event MUST be empty, and the event's {{Event/cancelable}} attribute MUST be false.</p>
             </section>
 
             <section>
                 <h3>The <dfn data-dfn-type="event">pointerout</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerout}} when any of the following occurs:</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointerout}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved out of an element.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element to move away from underneath an uncaptured pointer of a stationary pointing device.</li>
@@ -992,7 +3251,7 @@ function tilt2spherical(tiltX, tiltY) {
 
             <section>
                 <h3>The <dfn data-dfn-type="event">pointerleave</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerleave}} when any of the following occurs:</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{pointerleave}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved out of an element and all of its descendants.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element and all of its descendants to move away from underneath an uncaptured pointer of a stationary pointing device.</li>
@@ -1005,12 +3264,12 @@ function tilt2spherical(tiltX, tiltY) {
 
             <section>
                 <h3>The <dfn data-dfn-type="event">gotpointercapture</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{gotpointercapture}} when an element receives pointer capture. This event is fired at the element that is receiving pointer capture. Subsequent events for that pointer will be fired at this element. See the <a>setting pointer capture</a> and <a>process pending pointer capture</a> sections.</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{gotpointercapture}} when an element receives pointer capture. This event is fired at the element that is receiving pointer capture. Subsequent events for that pointer will be fired at this element. See the <a>setting pointer capture</a> and <a>process pending pointer capture</a> sections.</p>
             </section>
 
             <section>
                 <h3>The <dfn data-dfn-type="event">lostpointercapture</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{lostpointercapture}} after pointer capture is released for a pointer. This event MUST be fired prior to any subsequent events for the pointer after capture was released. This event is fired at the element from which pointer capture was removed. All subsequent events for the pointer except <a><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</a> follow normal hit testing mechanisms (out of scope for this specification) for determining the event target. See the <a>releasing pointer capture</a>, <a>implicit release of pointer capture</a>, and <a>process pending pointer capture</a> sections.</p>
+                <p>The  <a data-cite="infra">user agent</a> MUST <a>fire a pointer event</a> named {{lostpointercapture}} after pointer capture is released for a pointer. This event MUST be fired prior to any subsequent events for the pointer after capture was released. This event is fired at the element from which pointer capture was removed. All subsequent events for the pointer except <a><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</a> follow normal hit testing mechanisms (out of scope for this specification) for determining the event target. See the <a>releasing pointer capture</a>, <a>implicit release of pointer capture</a>, and <a>process pending pointer capture</a> sections.</p>
             </section>
 
             <section>
@@ -1224,7 +3483,7 @@ partial interface Navigator {
 
             <p>The <code>touch-action</code> CSS property determines whether <a>direct manipulation</a> interactions (which are not limited to touch, despite the property's name) MAY trigger the user agent's panning and zooming behavior. See the section on <a><code>touch-action</code> values</a>.</p>
 
-            <p>Right before starting to pan or zoom, the [=user agent=] MUST <a>suppress a pointer event stream</a> if all of the following conditions are true:</p>
+            <p>Right before starting to pan or zoom, the  <a data-cite="infra">user agent</a> MUST <a>suppress a pointer event stream</a> if all of the following conditions are true:</p>
             <ul>
                 <li>The user agent has determined (via methods out of scope for this specification) that a direct manipulation interaction is to be consumed for panning or zooming,</li>
                 <li>a {{pointerdown}} event has been sent for the pointer, and</li>
@@ -1256,13 +3515,13 @@ partial interface Navigator {
             <div class="note">The terms "panning" and "scrolling" are considered synonymous (or, more aptly, "panning" is "scrolling" using a direct manipulation input). Defining an interaction or gesture for triggering panning/scrolling, or for triggering behavior for the <code>auto</code> or <code>none</code> values, are out of scope for this specification.</div>
             <dl>
                 <dt>auto</dt>
-                <dd>The [=user agent=] MAY consider any permitted direct manipulation behaviors related to panning and zooming of the viewport that begin on the element.</dd>
+                <dd>The  <a data-cite="infra">user agent</a> MAY consider any permitted direct manipulation behaviors related to panning and zooming of the viewport that begin on the element.</dd>
                 <dt>none</dt>
                 <dd>Direct manipulation interactions that begin on the element MUST NOT trigger behaviors related to viewport panning and zooming.</dd>
                 <dt>pan-x<br>pan-left<br>pan-right<br>pan-y<br>pan-up<br>pan-down</dt>
-                <dd>The [=user agent=] MAY consider direct manipulation interactions that begin on the element only for the purposes of panning that starts in any of the directions specified by all of the listed values. Once panning has started, the direction may be reversed by the user even if panning that starts in the reversed direction is disallowed. In contrast, when panning is restricted to a single axis (for instance, with <code>pan-x</code> or <code>pan-y</code>), the axis cannot be changed during panning.</dd>
+                <dd>The  <a data-cite="infra">user agent</a> MAY consider direct manipulation interactions that begin on the element only for the purposes of panning that starts in any of the directions specified by all of the listed values. Once panning has started, the direction may be reversed by the user even if panning that starts in the reversed direction is disallowed. In contrast, when panning is restricted to a single axis (for instance, with <code>pan-x</code> or <code>pan-y</code>), the axis cannot be changed during panning.</dd>
                 <dt>manipulation</dt>
-                <dd>The [=user agent=] MAY consider direct manipulation interactions that begin on the element only for the purposes of panning and <strong>continuous</strong> zooming (such as pinch-zoom), but MUST NOT trigger other related behaviors that rely on multiple activations that must happen within a set period of time (such as double-tap to zoom, or double-tap and hold for single-finger zoom).</dd>
+                <dd>The  <a data-cite="infra">user agent</a> MAY consider direct manipulation interactions that begin on the element only for the purposes of panning and <strong>continuous</strong> zooming (such as pinch-zoom), but MUST NOT trigger other related behaviors that rely on multiple activations that must happen within a set period of time (such as double-tap to zoom, or double-tap and hold for single-finger zoom).</dd>
             </dl>
             <div class="note"><a data-cite="compat/#touch-action">Additional <code>touch-action</code> values</a> common in implementations are defined in [[COMPAT]].</div>
             <div class="note">The <code>touch-action</code> property only applies to elements that support both the CSS <code>width</code> and <code>height</code> properties (see [[CSS21]]). This restriction is designed to facilitate user agent optimizations for <em>low-latency</em> <a>direct manipulation</a> panning and zooming. For elements not supported by default, such as <code>&lt;span&gt;</code> which is a <em>non-replaced inline element</em>, authors can set the <code>display</code> CSS property to a value, such as <code>block</code>, that supports <code>width</code> and <code>height</code>. Future specifications could extend this API to all elements.</div>
@@ -1334,7 +3593,7 @@ partial interface Navigator {
         <section>
             <h2><dfn data-lt="set pointer capture">Setting pointer capture</dfn></h2>
             <p>Pointer capture is set on an |element| of type {{Element}} by calling the <code>element.setPointerCapture(pointerId)</code> method.
-                When this method is invoked, the [=user agent=] MUST run the following steps:</p>
+                When this method is invoked, the  <a data-cite="infra">user agent</a> MUST run the following steps:</p>
             <ol>
                 <li>If the {{PointerEvent/pointerId}} provided as the method's argument does not match any of the <a>active pointers</a>, then [=exception/throw=] a {{"NotFoundError"}} {{DOMException}}.</li>
                 <li>Let the |pointer| be the <a>active pointer</a> specified by the given {{PointerEvent/pointerId}}.</li>
@@ -1350,7 +3609,7 @@ partial interface Navigator {
 
         <section>
             <h2><dfn data-lt="release pointer capture">Releasing pointer capture</dfn></h2>
-            <p>Pointer capture is released on an element explicitly by calling the <code>element.releasePointerCapture(pointerId)</code> method. When this method is called, the [=user agent=] MUST run the following steps:</p>
+            <p>Pointer capture is released on an element explicitly by calling the <code>element.releasePointerCapture(pointerId)</code> method. When this method is called, the  <a data-cite="infra">user agent</a> MUST run the following steps:</p>
             <ol>
                 <li>If the {{PointerEvent/pointerId}} provided as the method's argument does not match any of the <a>active pointers</a> and these steps are not being invoked as a result of the <a>implicit release of pointer capture</a>, then [=exception/throw=] a {{"NotFoundError"}} {{DOMException}}.</li>
                 <li>If {{Element/hasPointerCapture}} is false for the {{Element}} with the specified {{PointerEvent/pointerId}}, then terminate these steps.</li>
@@ -1369,11 +3628,11 @@ partial interface Navigator {
         <section>
             <h2><dfn data-lt="implicitly release the pointer capture|implicitly releasing pointer capture">Implicit release of pointer capture</dfn></h2>
             <p>Immediately after firing the {{pointerup}} or {{pointercancel}} events,
-                the [=user agent=] MUST clear the <a>pending pointer capture target override</a>
+                the  <a data-cite="infra">user agent</a> MUST clear the <a>pending pointer capture target override</a>
                 for the {{PointerEvent/pointerId}} of the {{pointerup}} or {{pointercancel}} event that was just dispatched,
                 and then run <a>process pending pointer capture</a> steps to fire {{lostpointercapture}} if necessary.
                 After running <a>process pending pointer capture</a> steps,
-                if the pointer supports hover, [=user agent=] MUST also send corresponding boundary events necessary
+                if the pointer supports hover,  <a data-cite="infra">user agent</a> MUST also send corresponding boundary events necessary
                 to reflect the current position of the pointer with no capture.</p>
             <p>When the <a>pointer capture target override</a> is no longer [=connected=] [[DOM]],
                 the <a>pointer capture target override</a> SHOULD be set to the document.</p>
@@ -1384,7 +3643,7 @@ partial interface Navigator {
                 corresponding to the captured pointer being fired at the document
                 during the next <a>Process pending pointer capture</a> after the capture node is removed.
             </div>
-            <p>When a pointer lock [[PointerLock]] is successfully applied on an element, the [=user agent=] MUST run the steps as if the {{Element/releasePointerCapture}} method has been called if any element is set to be captured or pending to be captured.</p>
+            <p>When a pointer lock [[PointerLock]] is successfully applied on an element, the  <a data-cite="infra">user agent</a> MUST run the steps as if the {{Element/releasePointerCapture}} method has been called if any element is set to be captured or pending to be captured.</p>
         </section>
     </section>
 
@@ -1402,7 +3661,7 @@ partial interface Navigator {
             (such as coordinates, pressure, tangential pressure, tilt, twist, or contact geometry)
             of a pointer is updated. Instead, they may coalesce (combine/merge) multiple changes into
             a single {{pointermove}} or {{pointerrawupdate}} event. While
-            this approach helps in reducing the amount of event handling the [=user agent=] MUST perform,
+            this approach helps in reducing the amount of event handling the  <a data-cite="infra">user agent</a> MUST perform,
             it will naturally reduce the granularity and fidelity when tracking a pointer position,
             particularly for fast and large movements. Using the
            {{PointerEvent/getCoalescedEvents}} method
@@ -1490,7 +3749,7 @@ partial interface Navigator {
 
             <p>The order of all these dispatched events MUST match the actual order of the original events.
             For example if a {{pointerdown}} event causes the dispatch for the
-            coalesced {{pointermove}} events the [=user agent=] MUST first dispatch one {{pointermove}}
+            coalesced {{pointermove}} events the  <a data-cite="infra">user agent</a> MUST first dispatch one {{pointermove}}
             event with all those coalesced events of a {{PointerEvent/pointerId}} followed by the {{pointerdown}} event.</p>
             <div class="note">
                 <p>Here is an example of the actual events happening with increasing {{Event/timeStamp}} values and the
@@ -1621,7 +3880,7 @@ window.addEventListener("pointermove", function(event) {
 
     <section>
         <h1><dfn data-lt="compatibility mouse events">Compatibility mapping with mouse events</dfn></h1>
-        <p>The vast majority of web content existing today codes only to Mouse Events. The following describes an algorithm for how the [=user agent=] MAY map generic pointer input to mouse events for compatibility with this content.</p>
+        <p>The vast majority of web content existing today codes only to Mouse Events. The following describes an algorithm for how the  <a data-cite="infra">user agent</a> MAY map generic pointer input to mouse events for compatibility with this content.</p>
         <p>The compatibility mapping with mouse events is an OPTIONAL feature of this specification. User agents are encouraged to support the feature for best compatibility with existing legacy content.</p>
         <div class="note">
             <p>At a high level, compatibility mouse events are intended to be "interleaved" with their respective pointer events. However, this specific order is not mandatory, and user agents that implement compatibility mouse events MAY decide to delay or group the dispatch of mouse events, as long as their relative order is consistent.</p>
@@ -1721,7 +3980,7 @@ window.addEventListener("pointermove", function(event) {
                 </li>
                 <li>If the pointer event dispatched was {{pointerup}} or {{pointercancel}}, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
             </ol>
-            <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the [=user agent=] MUST NOT generate <em>both</em> the compatibility mouse events as described in this section, and the <a data-cite="touch-events/#mouse-events">fallback mouse events</a> outlined in [[TOUCH-EVENTS]].</p>
+            <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the  <a data-cite="infra">user agent</a> MUST NOT generate <em>both</em> the compatibility mouse events as described in this section, and the <a data-cite="touch-events/#mouse-events">fallback mouse events</a> outlined in [[TOUCH-EVENTS]].</p>
             <div class="note">
                 <p>The activation of an element (<code>click</code>) with a primary pointer that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (e.g. single finger on a touchscreen) would typically produce the following event sequence:</p>
                 <ol data-class="note-list">

--- a/index.html
+++ b/index.html
@@ -924,7 +924,7 @@ dictionary MouseEventInit : EventModifierInit {
 			<li><a>Set MouseEvent attributes from native</a> with |native|</li>
 			<li><a>Maybe send pointerdown event</a> with |event|</li>
 			<li>Let |result| = <a>dispatch</a> |event| at |target|</li>
-			<li>If |result| is true and |target| is a <a>focusable area</a> that is <a>click focusable</a>, then
+			<li>If |result| is true and |target| is a <a data-cite="html#focusable-area">focusable area</a> that is <a data-cite="html#click-focusable">click focusable</a>, then
 				<ol>
                     <li>Run the <a>focusing steps</a> at |target|</li>
                 </ol>

--- a/index.html
+++ b/index.html
@@ -4285,8 +4285,6 @@ window.addEventListener("pointermove", function(event) {
                 <div class="note">In some cases, touchpads (like those found on a laptop) will allow the user to scroll by "dragging" on the touchpad. However, this is generally achieved
                 by the touchpad generating "fake" mouse wheel events, so this wouldn't count as a direct manipulation.</div>
                 </dd>
-            <dt><dfn>hit test</dfn></dt>
-                <dd>The process by which the user agent determines a target element for a pointer event. Typically, this is determined by considering the pointer's location and also the visual layout of elements in a document on screen media.</dd>
             <dt><dfn>hysteresis</dfn></dt>
             <dd>A feature of human interface design to accept input values within a certain	range of location or time, in order to improve the user experience.  For example, allowing for small deviation in the time it takes for a user to double-click a mouse button is temporal hysteresis, and not immediately closing a nested menu if the user mouses out from the parent window when transitioning to the child menu is locative hysteresis.</dd>
             <dt><dfn data-lt="measurable property">measurable properties</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             noIDLSorting: true,
             doJsonLd: true,
             xref: {
-                specs: ["uievents", "css2"],
+                specs: ["uievents", "css2", "cssom-view"],
                 profile: "web-platform"
             },
             mdn: "pointerevents",
@@ -766,6 +766,17 @@ dictionary MouseEventInit : EventModifierInit {
 			of the mouse event.
             </p>
 
+            <h5><dfn>hit test</dfn></h4>
+
+			<ol class="algorithm">
+                <li>Let |pos|, the x,y coordinates relative to the viewport</li>
+
+
+			    <li>Return [[CSSOM-View]]'s {{Document/elementFromPoint()}} with |pos| (the frontmost DOM element at |pos|)
+			    <p class="note">
+			    To account for <a data-cite="html/#inert">inert</a> or <a data-cite="html/#concept-fe-disabled">disabled</a> elements. this should call {{Document/elementsFromPoint()}} and reject invalid elements.
+			</p></li>
+            </ol>
 		
 		    <h5>initialize a {{MouseEvent}}</h5>
 

--- a/index.html
+++ b/index.html
@@ -4537,6 +4537,11 @@ The following features are obsolete and should only be implemented by
             Jeffrey Yasskin,
             Navid Zolghadr.
         </p>
+        <p>
+            Thanks to those who took care of mouse and wheel events in the past:
+            Gary Kacmarcik,
+            Travis Leithead, and the <a href="https://www.w3.org/TR/2024/WD-uievents-20240907/#acknowledgements-contributors">various contributors over the years</a>.
+        </p>
         <p>Special thanks to those that helped pioneer the first edition of this model, including especially: Charu Chandiram, Peter Freiling, Nathan Furtwangler, Thomas Olsen, Matt Rakow, Ramu Ramanathan, Justin Rogers, Jacob Rossi, Reed Townsend and Steve Wright.</p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
             <ol class="algorithm">
-                <li>Let |pos|, the x,y coordinates relative to the viewport</li>
+                <li>Let |pos| be the x,y coordinates relative to the viewport</li>
 
 
 			    <li>Return [[CSSOM-View]]'s {{Document/elementFromPoint()}} with |pos| (the frontmost DOM element at |pos|)
@@ -833,10 +833,10 @@ dictionary MouseEventInit : EventModifierInit {
                     <a>Set mouse event modifiers</a> with |event|
                 </li>
 				<li>
-                    Set |event|.{{MouseEvent/button}} = 0
+                    Set |event|.{{MouseEvent/button}} to 0
                 </li>
 				<li>
-                    Set |event|.{{MouseEvent/buttons}} = <a>mouse button bitmask</a>
+                    Set |event|.{{MouseEvent/buttons}} to <a>mouse button bitmask</a>
                 </li>
                 <li>
 			        <a>Initialize PointerLock attributes for MouseEvent</a> with |event|
@@ -862,26 +862,26 @@ dictionary MouseEventInit : EventModifierInit {
 		    <li>Set |event|'s <a>altgraph flag</a> if <a>key modifier state</a> includes "AltGraph", unset it otherwise</li>
 			<li>Set |event|'s <a>meta flag</a> if <a>key modifier state</a> includes "Meta", unset it otherwise</li>
 
-			<li>Set |event|.{{MouseEvent/shiftKey}} = true if the event's <a>shift flag</a> is set, false otherwise</li>
-			<li>Set |event|.{{MouseEvent/ctrlKey}} = true if the event's <a>control flag</a> is set, false otherwise</li>
-			<li>Set |event|.{{MouseEvent/altKey}} = true if the event's <a>alt flag</a> or <a>altgraph flag</a> is set, false otherwise</li>
-			<li>Set |event|.{{MouseEvent/metaKey}} = true if the event's <a>meta flag</a> is set, false otherwise</li>
+			<li>Set |event|.{{MouseEvent/shiftKey}} to true if the event's <a>shift flag</a> is set, false otherwise</li>
+			<li>Set |event|.{{MouseEvent/ctrlKey}} to true if the event's <a>control flag</a> is set, false otherwise</li>
+			<li>Set |event|.{{MouseEvent/altKey}} to true if the event's <a>alt flag</a> or <a>altgraph flag</a> is set, false otherwise</li>
+			<li>Set |event|.{{MouseEvent/metaKey}} to true if the event's <a>meta flag</a> is set, false otherwise</li>
             </ol>
 		
 
 		
-		    <h5><dfn>create a cancelable MouseEvent</dfn></h5>
+		    <h5><dfn data-lt="creating a cancelable MouseEvent">create a cancelable MouseEvent</dfn></h5>
 
             <p class="warning">
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |eventType|, a DOMString containing a valid {{MouseEvent}} type</li>
-			<li>Let |eventTarget|, the {{EventTarget}} of the event</li>
-			<li>Let |bubbles| be "true"</li>
-			<li>Let |cancelable| be "true"</li>
+			<li>Let |eventType| be a DOMString containing a valid {{MouseEvent}} type</li>
+			<li>Let |eventTarget| be the {{EventTarget}} of the event</li>
+			<li>Let |bubbles| be true</li>
+			<li>Let |cancelable| be true</li>
 
-			<li>Let |event| = the result of <a data-lt="creating an event">creating a new event</a> using {{MouseEvent}}</li>
+			<li>Let |event| be the result of [=creating an event=] using {{MouseEvent}}</li>
 			<li><a>Initialize a MouseEvent</a> with |event|, |eventType|, |eventTarget|, |bubbles| and |cancelable|.</li>
 			<li>Return |event|</li>
             </ol>
@@ -889,18 +889,18 @@ dictionary MouseEventInit : EventModifierInit {
 		
 
 		
-		    <h5><dfn>create a non-cancelable MouseEvent</dfn></h5>
+		    <h5><dfn data-lt="creating a non-cancelable MouseEvent">create a non-cancelable MouseEvent</dfn></h5>
 
             <p class="warning">
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |eventType|, a DOMString containing a valid {{MouseEvent}} type</li>
-			<li>Let |eventTarget|, the {{EventTarget}} of the event</li>
+			<li>Let |eventType| be a DOMString containing a valid {{MouseEvent}} type</li>
+			<li>Let |eventTarget| be the {{EventTarget}} of the event</li>
 			<li>Let |bubbles| be "false"</li>
 			<li>Let |cancelable| be "false"</li>
 
-			<li>Let |event| = the result of <a data-lt="creating an event">creating a new event</a> using {{MouseEvent}}</li>
+			<li>Let |event| be the result of [=creating an event=] using {{MouseEvent}}</li>
 			<li><a>Initialize a MouseEvent</a> with |event|, |eventType|, |eventTarget|, |bubbles| and |cancelable|.</li>
 			<li>Return |event|</li>
             </ol>
@@ -915,7 +915,7 @@ dictionary MouseEventInit : EventModifierInit {
 
             <p>This will return a button ID suitable for storing in the {{MouseEvent}}'s {{MouseEvent/button}} attribute.</p>
 			<ol class="algorithm">
-			<li>Let |mbutton|, an ID that identifies a mouse button</li>
+			<li>Let |mbutton| be an ID that identifies a mouse button</li>
 			<li>If |mbutton| is the primary mouse button, then return 0</li>
 			<li>If |mbutton| is the auxiliary (middle)  mouse button, then return 1</li>
 			<li>If |mbutton| is the secondary mouse button, then return 2</li>
@@ -932,14 +932,14 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |event|, the {{MouseEvent}} to initialize</li>
-			<li>Let |native|, the native mouse event
+			<li>Let |event| be the {{MouseEvent}} to initialize</li>
+			<li>Let |native| be the native mouse event
 			<p class="ednote">TODO.</p>
                 </li>
 			<li>If |event|.{{Event/type}} is one of [ mousedown, mouseup ], then
                 <ol>
 				<li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
-				<li>Set |event|.{{MouseEvent/button}} = <a>calculate MouseEvent button attribute</a> with |mbutton|</li>
+				<li>Set |event|.{{MouseEvent/button}} to <a>calculate MouseEvent button attribute</a> with |mbutton|</li>
                 </ol>
             </li>
             </ol>
@@ -953,7 +953,7 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |native|, the native mousedown</li>
+			<li>Let |native| be the native mousedown</li>
 			<li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
 
 			<li>Update the <a>mouse button bitmask</a> as follows:
@@ -967,11 +967,11 @@ dictionary MouseEventInit : EventModifierInit {
 				</p>
                 </li>
                 </ol></li>
-			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
-			<li>Let |event| = <a>create a cancelable MouseEvent</a> with "mousedown", |target|</li>
+			<li>Let |target| be <a>hit test</a> with viewport-relative coordinates from |native|</li>
+			<li>Let |event| be the result of <a>creating a cancelable MouseEvent</a> with "mousedown", |target|</li>
 			<li><a>Set MouseEvent attributes from native</a> with |native|</li>
 			<li><a>Maybe send pointerdown event</a> with |event|</li>
-			<li>Let |result| = <a>dispatch</a> |event| at |target|</li>
+			<li>Let |result| be <a>dispatch</a> |event| at |target|</li>
 			<li>If |result| is true and |target| is a <a data-cite="html#focusable-area">focusable area</a> that is <a data-cite="html#click-focusable">click focusable</a>, then
 				<ol>
                     <li>Run the <a>focusing steps</a> at |target|</li>
@@ -992,7 +992,7 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			    <li>Let |native|, the native mouseup
+			    <li>Let |native| be the native mouseup
 			    <p class="note">
 			    Other mouse events can occur between the mousedown and mouseup.
 			    </p>
@@ -1006,8 +1006,8 @@ dictionary MouseEventInit : EventModifierInit {
 				    <li>If |mbutton| is the auxiliary (middle) mouse button, then clear the 0x04 bit</li>
                     </ol>
                 </li>
-			    <li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
-			    <li>Let |event| = <a>create a cancelable MouseEvent</a> with "mouseup", |target|</li>
+			    <li>Let |target| be <a>hit test</a> with viewport-relative coordinates from |native|</li>
+			    <li>Let |event| be the result of <a>creating a cancelable MouseEvent</a> with "mouseup", |target|</li>
 			    <li><a>Set MouseEvent attributes from native</a> with |native|</li>
 
 			    <li><a>Maybe send pointerup event</a> with |event|</li>
@@ -1024,12 +1024,12 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |native|, the native mouse click
+			<li>Let |native| be the native mouse click
 			<p class="note">
 			The platform should call this immediately after <a>handle native mouse up</a> for mouseups that generate clicks.
 			</p>
             </li>
-			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+			<li>Let |target| be <a>hit test</a> with viewport-relative coordinates from |native|</li>
 
 			<li><a>Send click event</a> with |native| and |target|.</li>
             </ol>
@@ -1042,17 +1042,17 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |native|, the native mousedown</li>
-			<li>Let |target|, the {{EventTarget}} of the event</li>
-			<li>Let |mbutton| = 1  (primary mouse button by default)</li>
+			<li>Let |native| be the native mousedown</li>
+			<li>Let |target| be the {{EventTarget}} of the event</li>
+			<li>Let |mbutton| be 1  (primary mouse button by default)</li>
 			<li>If |native| is valid, then
 				<ol class="algorithm">
 			    <li>Let |mbutton| be an ID from |native| that identifies which mouse button was pressed</li>
                 </ol>
             </li>
-			<li>Set |eventType| = "click" if |mbutton| is the primary mouse button, otherwise "auxclick"</li>
+			<li>Set |eventType| to "click" if |mbutton| is the primary mouse button, otherwise "auxclick"</li>
 
-			<li>Let |event| = <a>create a PointerEvent</a> with |eventType| and |target|</li>
+			<li>Let |event| be the result of <a>creating a PointerEvent</a> with |eventType| and |target|</li>
 
 			<li>If |native| is valid, then
 				<ol class="algorithm">
@@ -1093,7 +1093,7 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |native|, the native mouse double click
+			<li>Let |native| be the native mouse double click
 			<p class="note">
 			This should be called immediately after handle native mouse click for mouse clicks that generate double clicks.
 			</p>
@@ -1102,9 +1102,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 			<li>If |mbutton| is not the primary mouse button, then return</li>
 
-			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+			<li>Let |target| be <a>hit test</a> with viewport-relative coordinates from |native|</li>
 
-			<li>Let |event| = <a>create a PointerEvent</a> with "dblclick" and |target|</li>
+			<li>Let |event| be the result of <a>creating a PointerEvent</a> with "dblclick" and |target|</li>
 			<li><a>Set MouseEvent attributes from native</a> with |event|, |native|</li>
 			<li>If |event|.{{MouseEvent/screenX}} is not an integer value, then round it.</li>
 			<li>If |event|.{{MouseEvent/screenY}} is not an integer value, then round it.</li>
@@ -1120,14 +1120,14 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |native|, the native mouse move
+			<li>Let |native| be the native mouse move
 			<p class="issue">
 			This algorithm makes assumptions about the dispatch of PointerEvents because they are not currently specified explicitly. Once <a href="https://github.com/w3c/pointerevents/issues/285">pointerevents/285</a> is resolved this may need to be updated.
 			</p>
             </li>
-			<li>Let |target| = <a>hit test</a> with viewport-relative coordinates from |native|</li>
+			<li>Let |target| be <a>hit test</a> with viewport-relative coordinates from |native|</li>
 
-			<li>Let |targetDomPath| = [=tree/inclusive ancestors=] of |target|</li>
+			<li>Let |targetDomPath| be [=tree/inclusive ancestors=] of |target|</li>
 
 			<li>Generate events for leaving the current element:
 
@@ -1135,7 +1135,7 @@ dictionary MouseEventInit : EventModifierInit {
 			    <li>If <a>last mouse element</a> is defined and not equal to |target|, then
 
 					<ol class="algorithm">
-			        <li>Let |mouseout| = <a>create a cancelable MouseEvent</a> with "mouseout" and <a>last mouse element</a>
+			        <li>Let |mouseout| be the result of <a>creating a cancelable MouseEvent</a> with "mouseout" and <a>last mouse element</a>
 
 					<p class="ednote">
 					TODO: Set |mouseout| attributes from |native|. +CSSOM attributes.
@@ -1162,7 +1162,7 @@ dictionary MouseEventInit : EventModifierInit {
 						</p>
 
 						<ol class="algorithm">
-			            <li>Let |mouseleave| = <a>create a non-cancelable MouseEvent</a> with "mouseleave" and |element|</li>
+			            <li>Let |mouseleave| be the result of <a>creating a non-cancelable MouseEvent</a> with "mouseleave" and |element|</li>
 
 						<li>Set |mouseleave|.{{Event.composed}}
  = false
@@ -1173,7 +1173,7 @@ dictionary MouseEventInit : EventModifierInit {
                         </li>
 						<li><a>Maybe send pointerleave event</a> with |mouseleave|</li>
 
-						<li>Let |result| = <a>dispatch</a> |mouseleave| at |element|</li>
+						<li>Let |result| be <a>dispatch</a> |mouseleave| at |element|</li>
                         </ol>
                         </li>
                 </li>
@@ -1185,7 +1185,7 @@ dictionary MouseEventInit : EventModifierInit {
 			    <li>If |target| is not <a>last mouse element</a>, then
 
 					<ol class="algorithm">
-			        <li>Let |mouseover| = <a>create a cancelable MouseEvent</a> with "mouseover" and |target|
+			        <li>Let |mouseover| be the result of <a>creating a cancelable MouseEvent</a> with "mouseover" and |target|
 
 					<p class="ednote">
 					TODO: Set |mouseout| attributes from |native|. +CSSOM attributes.
@@ -1208,7 +1208,7 @@ dictionary MouseEventInit : EventModifierInit {
 						</p>
 
 						<ol class="algorithm">
-			            <li>Let |mouseenter| = <a>create a non-cancelable MouseEvent</a> with "mouseenter" and |element|</li>
+			            <li>Let |mouseenter| be the result of <a>creating a non-cancelable MouseEvent</a> with "mouseenter" and |element|</li>
 
 						<li>Set |mouseenter|.{{Event.composed}}
  = false
@@ -1225,7 +1225,7 @@ dictionary MouseEventInit : EventModifierInit {
 						Check compat for shadow DOM elements. Chrome/Linux fires this event at the element and the shadow root.
 						</p>
                         </li>
-						<li>Let |result| = <a>dispatch</a> |mouseenter| at |element|</li>
+						<li>Let |result| be <a>dispatch</a> |mouseenter| at |element|</li>
                     </ol>
                     </li>
 					<li>Set <a>last mouse element</a> to |target|</li>
@@ -1234,7 +1234,7 @@ dictionary MouseEventInit : EventModifierInit {
                 </li>
             </ol>
             </li>
-			<li>Let |mousemove| = <a>create a cancelable MouseEvent</a> with "mousemove" and |element|</li>
+			<li>Let |mousemove| be the result of <a>creating a cancelable MouseEvent</a> with "mousemove" and |element|</li>
 
 			<li><a>Set PointerLock attributes for mousemove</a></li>
 
@@ -1251,16 +1251,16 @@ dictionary MouseEventInit : EventModifierInit {
                 This section needs to be revised.
 
 			<ol class="algorithm">
-			<li>Let |native|, the native mousedown or pointer event</li>
-			<li>Let |target|, the {{EventTarget}} of the event</li>
+			<li>Let |native| be the native mousedown or pointer event</li>
+			<li>Let |target| be the {{EventTarget}} of the event</li>
 				<ol class="algorithm">
-			    <li>Let |menuevent| = <a>create a PointerEvent</a> with "contextmenu", |target|</li>
+			    <li>Let |menuevent| be the result of <a>creating a PointerEvent</a> with "contextmenu", |target|</li>
 				<li>If |native| is valid, then
 					<ol class="algorithm">
 			        <li><a>Set MouseEvent attributes from native</a> with |native|</li>
                     </ol>
                 </li>
-				<li>Let |result| = <a>dispatch</a> |menuevent| at |target|</li>
+				<li>Let |result| be <a>dispatch</a> |menuevent| at |target|</li>
 				<li>If |result| is true, then show the UA context menu</li>
                 </ol>
 			<p class="note">
@@ -2974,8 +2974,8 @@ function tilt2spherical(tiltX, tiltY) {
                             |created PointerEvent from MouseEvent"
                     >create {{PointerEvent}} from {{MouseEvent}}</dfn></h4>
 			    <ol class="algorithm">
-			        <li>Let |eventType|, a {{DOMString}} containing the event type</li>
-			        <li>Let |mouseevent|, the corresponding {{MouseEvent}}</li>
+			        <li>Let |eventType| be a {{DOMString}} containing the event type</li>
+			        <li>Let |mouseevent| be the corresponding {{MouseEvent}}</li>
 			        <li>Let |event| be the result of
 				        [=creating an event=] using {{PointerEvent}}</li>
 			        <li>Let |target| be the |mouseevent|.{{Event/target}}</li>
@@ -2987,7 +2987,7 @@ function tilt2spherical(tiltX, tiltY) {
 		    <section>
 		        <h4><dfn class="export">maybe send pointerout event</dfn></h4>
 			    <ol class="algorithm">
-			        <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+			        <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}</li>
 			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
 			        <li>Set pointerevent attributes
 				<p class="ednote">TODO.</p></li>
@@ -2998,7 +2998,7 @@ function tilt2spherical(tiltX, tiltY) {
 		    <section>
 		        <h4><dfn class="export">maybe send pointerleave event</dfn></h4>
 			    <ol class="algorithm">
-                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+                    <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}</li>
 			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
 			        <li>Set pointerevent attributes
 				<p class="ednote">TODO.</p></li>
@@ -3009,7 +3009,7 @@ function tilt2spherical(tiltX, tiltY) {
 		    <section>
 		        <h4><dfn class="export">maybe send pointerover event</dfn></h4>
 			    <ol class="algorithm">
-                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+                    <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}</li>
 			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
 			        <li>Set pointerevent attributes
 				<p class="ednote">TODO.</p></li>
@@ -3021,7 +3021,7 @@ function tilt2spherical(tiltX, tiltY) {
 		        <h4><dfn class="export">maybe send pointerenter event</dfn></h4>
 
 			    <ol class="algorithm">
-                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}</li>
+                    <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}</li>
 			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|</li>
 			        <li>Set pointerevent attributes
                 <p class="ednote">TODO.</p></li>
@@ -3033,7 +3033,7 @@ function tilt2spherical(tiltX, tiltY) {
 		        <h4><dfn class="export">maybe send pointermove event</dfn></h4>
 
 			    <ol class="algorithm">
-                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+                    <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}
 			<p class="ednote">
 			Can this send pointermove and pointerrawupdate? Or do we need 2 methods?
 			</p>
@@ -3055,7 +3055,7 @@ function tilt2spherical(tiltX, tiltY) {
 		        <h4><dfn class="export">maybe send pointerdown event</dfn></h4>
 
 			    <ol class="algorithm">
-                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+                    <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}
 			        <p class="note">
 			            Unlike <code>mousedown</code> events, {{pointerdown}}
 			            events are not nested when multiple buttons are pressed.
@@ -3075,7 +3075,7 @@ function tilt2spherical(tiltX, tiltY) {
                 <h4><dfn class="export">maybe send pointerrawupdate event</dfn></h4>
 
                 <ol class="algorithm">
-                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+                    <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}
 			        <li>Let |target| be the |mouseout|.{{Event/target}}</li>
 			        <li>[=dispatch=] |pointerout| at |target|</li>
                 </ol>
@@ -3085,7 +3085,7 @@ function tilt2spherical(tiltX, tiltY) {
 		        <h4><dfn class="export">maybe send pointerup event</dfn></h4>
 
 			    <ol class="algorithm">
-                    <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
+                    <li>Let |mouseout| be the corresponding mouseout {{MouseEvent}}
 			        <p class="note">
 			            Unlike <code>mouseup</code> events, {{pointerup}} events are not nested when multiple buttons are pressed. The {{MouseEvent}} is passed so that the fields can be copied into the PointerEvent.
 			        </p>

--- a/index.html
+++ b/index.html
@@ -704,6 +704,9 @@ dictionary MouseEventInit : EventModifierInit {
 		
             <h5>Constructing Mouse Events</h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<p>
                 Generally, when a constructor of an {{Event}} interface, or of an interface inherited from the {{Event}} interface, is invoked, the steps described in [[DOM]] should be followed. However the {{MouseEvent}} interfaces provide additional dictionary members for initializing the internal state of the {{Event}} object's key modifiers: specifically, the internal state queried for using the {{MouseEvent/getModifierState()}} methods. This section supplements the [[DOM]] steps for intializing a new {{MouseEvent}} object with these optional modifier states.
             </p>
@@ -728,6 +731,8 @@ dictionary MouseEventInit : EventModifierInit {
 
 		    <h5>Global State for MouseEvent</h5>
 
+            <p class="warning">
+                This section needs to be revised.
 
 			    <h6>User Agent-Level State</h6>
 
@@ -755,6 +760,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 		    <h5>Internal State for MouseEvent</h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<p>
                 A {{MouseEvent}} has the following internal flags that are used to track the state of various modifier keys:
 				<dfn>shift flag</dfn>,
@@ -768,17 +776,23 @@ dictionary MouseEventInit : EventModifierInit {
 
             <h5><dfn>hit test</dfn></h4>
 
-			<ol class="algorithm">
+            <p class="warning">
+                This section needs to be revised.
+
+            <ol class="algorithm">
                 <li>Let |pos|, the x,y coordinates relative to the viewport</li>
 
 
 			    <li>Return [[CSSOM-View]]'s {{Document/elementFromPoint()}} with |pos| (the frontmost DOM element at |pos|)
 			    <p class="note">
 			    To account for <a data-cite="html/#inert">inert</a> or <a data-cite="html/#concept-fe-disabled">disabled</a> elements. this should call {{Document/elementsFromPoint()}} and reject invalid elements.
-			</p></li>
+			    </p></li>
             </ol>
 		
 		    <h5>initialize a {{MouseEvent}}</h5>
+
+            <p class="warning">
+                This section needs to be revised.
 
             <p>
                 To <dfn class="export">initialize a MouseEvent</dfn> with |event|, |eventType| and |eventTarget|, |bubbles|, and |cancelable|, run the following steps:
@@ -822,6 +836,9 @@ dictionary MouseEventInit : EventModifierInit {
 		
 		    <h5><dfn>set mouse event modifiers</dfn></h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<ol class="algorithm">
 			<li>Let |event| be the {{MouseEvent}} to update</li>
 			<li>Set |event|'s <a>shift flag</a> if <a>key modifier state</a> includes "Shift", unset it otherwise</li>
@@ -840,6 +857,9 @@ dictionary MouseEventInit : EventModifierInit {
 		
 		    <h5><dfn>create a cancelable MouseEvent</dfn></h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<ol class="algorithm">
 			<li>Let |eventType|, a DOMString containing a valid {{MouseEvent}} type</li>
 			<li>Let |eventTarget|, the {{EventTarget}} of the event</li>
@@ -856,6 +876,9 @@ dictionary MouseEventInit : EventModifierInit {
 		
 		    <h5><dfn>create a non-cancelable MouseEvent</dfn></h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<ol class="algorithm">
 			<li>Let |eventType|, a DOMString containing a valid {{MouseEvent}} type</li>
 			<li>Let |eventTarget|, the {{EventTarget}} of the event</li>
@@ -871,6 +894,10 @@ dictionary MouseEventInit : EventModifierInit {
 
 		
 		    <h5><dfn>calculate MouseEvent button attribute</dfn></h5>
+
+            <p class="warning">
+                This section needs to be revised.
+
             <p>This will return a button ID suitable for storing in the {{MouseEvent}}'s {{MouseEvent/button}} attribute.</p>
 			<ol class="algorithm">
 			<li>Let |mbutton|, an ID that identifies a mouse button</li>
@@ -885,6 +912,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 		
 		    <h5><dfn>set MouseEvent attributes from native</dfn></h5>
+
+            <p class="warning">
+                This section needs to be revised.
 
 			<ol class="algorithm">
 			<li>Let |event|, the {{MouseEvent}} to initialize</li>
@@ -903,6 +933,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 		
 		    <h5><dfn>handle native mouse down</dfn></h5>
+
+            <p class="warning">
+                This section needs to be revised.
 
 			<ol class="algorithm">
 			<li>Let |native|, the native mousedown</li>
@@ -940,6 +973,9 @@ dictionary MouseEventInit : EventModifierInit {
 		
 		    <h5><dfn>handle native mouse up</dfn></h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<ol class="algorithm">
 			    <li>Let |native|, the native mouseup
 			    <p class="note">
@@ -969,6 +1005,9 @@ dictionary MouseEventInit : EventModifierInit {
 		
 		    <h5><dfn>handle native mouse click</dfn></h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<ol class="algorithm">
 			<li>Let |native|, the native mouse click
 			<p class="note">
@@ -983,6 +1022,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 		
 		    <h5><dfn>send click event</dfn></h5>
+
+            <p class="warning">
+                This section needs to be revised.
 
 			<ol class="algorithm">
 			<li>Let |native|, the native mousedown</li>
@@ -1032,6 +1074,9 @@ dictionary MouseEventInit : EventModifierInit {
 		
 		    <h5><dfn>handle native mouse double click</dfn></h5>
 
+            <p class="warning">
+                This section needs to be revised.
+
 			<ol class="algorithm">
 			<li>Let |native|, the native mouse double click
 			<p class="note">
@@ -1055,6 +1100,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 		
 		    <h5><dfn>handle native mouse move</dfn></h5>
+
+            <p class="warning">
+                This section needs to be revised.
 
 			<ol class="algorithm">
 			<li>Let |native|, the native mouse move
@@ -1183,6 +1231,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 		
 		    <h5><dfn>maybe show context menu</dfn></h5>
+
+            <p class="warning">
+                This section needs to be revised.
 
 			<ol class="algorithm">
 			<li>Let |native|, the native mousedown or pointer event</li>

--- a/index.html
+++ b/index.html
@@ -4213,7 +4213,7 @@ window.addEventListener("pointermove", function(event) {
                 <li>If the <code>isPrimary</code> property for the pointer event to be dispatched is <code>false</code> then dispatch the pointer event and terminate these steps.</li>
                 <li>If the pointer event to be dispatched is a {{pointerdown}}, {{pointerup}} or {{pointermove}} event, or a {{pointerleave}} event at the <code>window</code>, dispatch compatibility mouse transition events as described in <a>Tracking the effective position of the legacy mouse pointer</a>.</li>
                 <li>Dispatch the pointer event.</li>
-                <li>If the pointer event dispatched was {{pointerdown}} and the event was <a data-lt="canceled event">canceled</a>, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
+                <li>If the pointer event dispatched was {{pointerdown}} and event's [=Event/canceled flag=] is set, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
                 <li>If the <code>PREVENT MOUSE EVENT</code> flag is <strong>not</strong> set for this <code>pointerType</code> and the pointer event dispatched was:
                     <ul>
                         <li>{{pointerdown}}, then fire a <code>mousedown</code> event.</li>
@@ -4240,7 +4240,7 @@ window.addEventListener("pointermove", function(event) {
                 <li>If the pointer event to be dispatched is {{pointerover}} and the {{pointerdown}} event has not yet been dispatched for this pointer, then fire a <code>mousemove</code> event (for compatibility with legacy mouse-specific code).</li>
                 <li>If the pointer event to be dispatched is a {{pointerdown}}, {{pointerup}} or {{pointermove}} event, or a {{pointerleave}} event at the <code>window</code>, dispatch compatibility mouse transition events as described in <a>Tracking the effective position of the legacy mouse pointer</a>.</li>
                 <li>Dispatch the pointer event.</li>
-                <li>If the pointer event dispatched was {{pointerdown}} and the event was <a data-lt="canceled event">canceled</a>, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
+                <li>If the pointer event dispatched was {{pointerdown}} and event's [=Event/canceled flag=] is set, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
                 <li>If the <code>PREVENT MOUSE EVENT</code> flag is <strong>not</strong> set for this <code>pointerType</code> and the pointer event dispatched was:
                     <ul>
                         <li>{{pointerdown}}, then fire a <code>mousedown</code> event.</li>
@@ -4271,7 +4271,7 @@ window.addEventListener("pointermove", function(event) {
                     <li><code>mouseleave</code></li>
                     <li><code>click</code></li>
                 </ol>
-                <p>If, however, the {{pointerdown}} event is <a data-lt="canceled event">canceled</a> during this interaction then the sequence of events would be:</p>
+                <p>If, however, the {{pointerdown}} event [=Event/canceled flag=] is set during this interaction then the sequence of events would be:</p>
                 <ol data-class="note-list">
                     <li><code>mousemove</code></li>
                     <li>{{pointerover}}</li>
@@ -4334,8 +4334,6 @@ window.addEventListener("pointermove", function(event) {
                     </ul>
                     <div class="note">On some platforms, the set of active pointers includes all pointer input to the device, including any that are not targeted at the user agent (e.g. those targeted at other applications).</div>
                 </dd>
-            <dt><dfn>canceled event</dfn></dt>
-                <dd>An event whose default action was prevented by means of <code>preventDefault()</code>, returning <code>false</code> in an event handler, or other means as defined by [[UIEVENTS]] and [[HTML]].</dd>
             <dt><dfn>contact geometry</dfn></dt>
                 <dd>The bounding box of an input (most commonly, touch) on a digitizer. This typically refers to devices with coarser pointer input resolution than a single pixel. Some devices do not report this data at all.</dd>
             <dt><dfn>delta</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             <figcaption>A pointer is a hardware-agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen.</figcaption>
         </figure>
 
-        <p>The events for handling generic pointer input look a lot like those for mouse: {{GlobalEventHandlers/pointerdown}}, {{GlobalEventHandlers/pointermove}}, {{GlobalEventHandlers/pointerup}}, {{GlobalEventHandlers/pointerover}}, {{GlobalEventHandlers/pointerout}}, and so on. This facilitates easy content migration from Mouse Events to Pointer Events.
+        <p>The events for handling generic pointer input look a lot like those for mouse: {{pointerdown}}, {{pointermove}}, {{pointerup}}, {{pointerover}}, {{pointerout}}, and so on. This facilitates easy content migration from Mouse Events to Pointer Events.
         Pointer Events provide all the usual properties present in Mouse Events (including client coordinates, target element, button states) in addition to new properties for other forms of input, such as pressure, contact geometry, tilt. Authors can easily code to Pointer Events to share logic between different input types where it makes sense, and customize for a particular type of input only where necessary to get the best experience.</p>
         <p>While Pointer Events are sourced from a variety of input devices, they are not defined as being generated from some other set of device-specific events. While possible and encouraged for compatibility, this spec does not require other device-specific events be supported (such as mouse events or touch events). A user agent could support pointer events without supporting any other device events. For compatibility with content written to mouse-specific events, this specification does provide an optional section describing how to generate <a>compatibility mouse events</a> based on pointer input from devices other than a mouse.</p>
 
@@ -387,14 +387,14 @@ interface PointerEvent : MouseEvent {
                 <h3>Button states</h3>
                 <section>
                     <h4><dfn data-lt="chorded buttons">Chorded button interactions</dfn></h4>
-                    <p>Some pointer devices, such as mouse or pen, support multiple buttons. In the [[UIEVENTS]] Mouse Event model, each button press produces a <code>mousedown</code> and <code>mouseup</code> event. To better abstract this hardware difference and simplify cross-device input authoring, Pointer Events do not fire overlapping {{GlobalEventHandlers/pointerdown}} and {{GlobalEventHandlers/pointerup}} events for chorded button presses (depressing an additional button while another button on the pointer device is already depressed).</p>
+                    <p>Some pointer devices, such as mouse or pen, support multiple buttons. In the [[UIEVENTS]] Mouse Event model, each button press produces a <code>mousedown</code> and <code>mouseup</code> event. To better abstract this hardware difference and simplify cross-device input authoring, Pointer Events do not fire overlapping {{pointerdown}} and {{pointerup}} events for chorded button presses (depressing an additional button while another button on the pointer device is already depressed).</p>
                     <p>Instead, chorded button presses can be detected by inspecting changes to the <code>button</code> and <code>buttons</code> properties. The <code>button</code> and <code>buttons</code> properties are inherited from the {{MouseEvent}} interface, but with a change in semantics and values, as outlined in the following sections.</p>
                     <p>The modifications to the <code>button</code> and <code>buttons</code> properties apply only to pointer events. However for <code>click</code>, <code>auxclick</code> and <code>contextmenu</code> the value of <code>button</code> and <code>buttons</code> MUST follow [[UIEVENTS]], as is the case for <a>compatibility mouse events</a> .</p>
                 </section>
 
                 <section>
                     <h4>The <code>button</code> property</h4>
-                    <p>To identify button state transitions in any pointer event (and not just {{GlobalEventHandlers/pointerdown}} and {{GlobalEventHandlers/pointerup}}), the <code>button</code> property indicates the device button whose state change fired the event.</p>
+                    <p>To identify button state transitions in any pointer event (and not just {{pointerdown}} and {{pointerup}}), the <code>button</code> property indicates the device button whose state change fired the event.</p>
                     <table class="data">
                         <thead><tr><th>Device Button Changes</th><th><code>button</code></th></tr></thead>
                         <tbody>
@@ -407,7 +407,7 @@ interface PointerEvent : MouseEvent {
                             <tr><td>Pen eraser button</td><td>5</td></tr>
                         </tbody>
                     </table>
-                    <div class="note">During a mouse drag, the value of the <code>button</code> property in a {{GlobalEventHandlers/pointermove}} event will be different from that in a <code>mousemove</code> event. For example, while moving the mouse with the right button pressed, the {{GlobalEventHandlers/pointermove}} events will have the <code>button</code> value -1, but the <code>mousemove</code> events will have the <code>button</code> value 2.</div>
+                    <div class="note">During a mouse drag, the value of the <code>button</code> property in a {{pointermove}} event will be different from that in a <code>mousemove</code> event. For example, while moving the mouse with the right button pressed, the {{pointermove}} events will have the <code>button</code> value -1, but the <code>mousemove</code> events will have the <code>button</code> value 2.</div>
                 </section>
 
                 <section>
@@ -446,7 +446,7 @@ interface PointerEvent : MouseEvent {
             <section>
                 <h3>Firing events using the <code>PointerEvent</code> interface</h3>
                 <p>To <dfn>fire a pointer event</dfn> named |e| means to [=fire an event=] named |e| using <a>PointerEvent</a> whose attributes are set as defined in {{PointerEvent}} Interface and <a>Attributes and Default Actions</a>.</p>
-                <p>If the event is not a {{GlobalEventHandlers/gotpointercapture}}, {{GlobalEventHandlers/lostpointercapture}}, <code>click</code>, <code>auxclick</code> or <code>contextmenu</code> event, run the <a>process pending pointer capture</a> steps for this <code>PointerEvent</code>.</p>
+                <p>If the event is not a {{gotpointercapture}}, {{lostpointercapture}}, <code>click</code>, <code>auxclick</code> or <code>contextmenu</code> event, run the <a>process pending pointer capture</a> steps for this <code>PointerEvent</code>.</p>
 
                 <p><dfn>Determine the target</dfn> at which the event is fired as follows:</p>
                 <ul>
@@ -456,12 +456,12 @@ interface PointerEvent : MouseEvent {
 
                 <p>Let |targetDocument| be target's [=Node/node document=] [[DOM]].</p>
 
-                <p>If the event is {{GlobalEventHandlers/pointerdown}}, {{GlobalEventHandlers/pointermove}}, or {{GlobalEventHandlers/pointerup}}, set <a>active document</a> for the event's {{PointerEvent/pointerId}} to |targetDocument|.</p>
+                <p>If the event is {{pointerdown}}, {{pointermove}}, or {{pointerup}}, set <a>active document</a> for the event's {{PointerEvent/pointerId}} to |targetDocument|.</p>
 
-                <p>If the event is {{GlobalEventHandlers/pointerdown}}, the associated device is a direct manipulation device, and the target is an {{Element}},
+                <p>If the event is {{pointerdown}}, the associated device is a direct manipulation device, and the target is an {{Element}},
                     then <a>set pointer capture</a> for this {{PointerEvent/pointerId}} to the target element as described in <a>implicit pointer capture</a>.</p>
 
-                <p>Before firing this event, the [=user agent=] SHOULD treat the target as if the pointing device has moved over it from the |previousTarget| for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]]. If the |needsOverEvent| flag is set, a {{GlobalEventHandlers/pointerover}} event is needed even if the target element is the same.</p>
+                <p>Before firing this event, the [=user agent=] SHOULD treat the target as if the pointing device has moved over it from the |previousTarget| for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]]. If the |needsOverEvent| flag is set, a {{pointerover}} event is needed even if the target element is the same.</p>
 
                 <p>Fire the event to the determined target.</p>
 
@@ -484,68 +484,68 @@ interface PointerEvent : MouseEvent {
                         </thead>
                         <tbody>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointerover}}</td>
+                                <td>{{pointerover}}</td>
                                 <td>Yes</td>
                                 <td>Yes</td>
                                 <td>None</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointerenter}}</td>
+                                <td>{{pointerenter}}</td>
                                 <td>No</td>
                                 <td>No</td>
                                 <td>None</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointerdown}}</td>
+                                <td>{{pointerdown}}</td>
                                 <td>Yes</td>
                                 <td>Yes</td>
                                 <td>Varies: when the pointer is primary, all default actions of the <code>mousedown</code> event
                                     <br>Canceling this event also prevents subsequent firing of <a>compatibility mouse events</a>.</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointermove}}</td>
+                                <td>{{pointermove}}</td>
                                 <td>Yes</td>
                                 <td>Yes</td>
                                 <td>Varies: when the pointer is primary, all default actions of <code>mousemove</code></td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointerrawupdate}}</td>
+                                <td>{{pointerrawupdate}}</td>
                                 <td>Yes</td>
                                 <td>No</td>
                                 <td>None</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointerup}}</td>
+                                <td>{{pointerup}}</td>
                                 <td>Yes</td>
                                 <td>Yes</td>
                                 <td>Varies: when the pointer is primary, all default actions of <code>mouseup</code></td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointercancel}}</td>
+                                <td>{{pointercancel}}</td>
                                 <td>Yes</td>
                                 <td>No</td>
                                 <td>None</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointerout}}</td>
+                                <td>{{pointerout}}</td>
                                 <td>Yes</td>
                                 <td>Yes</td>
                                 <td>None</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/pointerleave}}</td>
+                                <td>{{pointerleave}}</td>
                                 <td>No</td>
                                 <td>No</td>
                                 <td>None</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/gotpointercapture}}</td>
+                                <td>{{gotpointercapture}}</td>
                                 <td>Yes</td>
                                 <td>No</td>
                                 <td>None</td>
                             </tr>
                             <tr>
-                                <td>{{GlobalEventHandlers/lostpointercapture}}</td>
+                                <td>{{lostpointercapture}}</td>
                                 <td>Yes</td>
                                 <td>No</td>
                                 <td>None</td>
@@ -555,26 +555,26 @@ interface PointerEvent : MouseEvent {
 
                     <p>Viewport manipulations (panning and zooming) — generally, as a result of a <a>direct manipulation</a> interaction — are intentionally NOT a default action of pointer events, meaning that these behaviors (e.g. panning a page as a result of moving a finger on a touchscreen) cannot be suppressed by canceling a pointer event. Authors must instead use <code>touch-action</code> to explicitly <a>declare the direct manipulation behavior</a> for a region of the document. Removing this dependency on the cancelation of events facilitates performance optimizations by the user agent.</p>
 
-                    <p>For {{GlobalEventHandlers/pointerenter}} and {{GlobalEventHandlers/pointerleave}} events, the {{EventInit/composed}} [[DOM]] attribute SHOULD be <code>false</code>; for all other pointer events in the table above, the attribute SHOULD be <code>true</code>.</p>
+                    <p>For {{pointerenter}} and {{pointerleave}} events, the {{EventInit/composed}} [[DOM]] attribute SHOULD be <code>false</code>; for all other pointer events in the table above, the attribute SHOULD be <code>true</code>.</p>
 
                     <p>For all pointer events in the table above, the {{UIEvent/detail}} [[UIEVENTS]] attribute SHOULD be 0.</p>
                     <div class="note">Many user agents expose non-standard attributes <code>fromElement</code> and <code>toElement</code> in MouseEvents to support legacy content. We encourage those user agents to set the values of those (inherited) attributes in PointerEvents to <code>null</code> to transition authors to the use of standardized alternates (<code>target</code> and <code>relatedTarget</code>).</div>
-                    <p>Similar to <code>MouseEvent</code> {{MouseEventInit/relatedTarget}}, the <code>relatedTarget</code> should be initialized to the element whose bounds the pointer just left (in the case of a {{GlobalEventHandlers/pointerover}} or <code>pointerenter</code> event) or the element whose bounds the pointer is entering (in the case of a {{GlobalEventHandlers/pointerout}} or {{GlobalEventHandlers/pointerleave}}). For other pointer events, this value will default to null. Note that when an element receives the pointer capture all the following events for that pointer are considered to be inside the boundary of the capturing element.</p>
-                    <p>For {{GlobalEventHandlers/gotpointercapture}} and {{GlobalEventHandlers/lostpointercapture}} events, all the attributes except the ones defined in the table above should be the same as the Pointer Event that caused the user agent to run the <a>process pending pointer capture</a> steps and fire the {{GlobalEventHandlers/gotpointercapture}} and {{GlobalEventHandlers/lostpointercapture}} events.</p>
+                    <p>Similar to <code>MouseEvent</code> {{MouseEventInit/relatedTarget}}, the <code>relatedTarget</code> should be initialized to the element whose bounds the pointer just left (in the case of a {{pointerover}} or <code>pointerenter</code> event) or the element whose bounds the pointer is entering (in the case of a {{pointerout}} or {{pointerleave}}). For other pointer events, this value will default to null. Note that when an element receives the pointer capture all the following events for that pointer are considered to be inside the boundary of the capturing element.</p>
+                    <p>For {{gotpointercapture}} and {{lostpointercapture}} events, all the attributes except the ones defined in the table above should be the same as the Pointer Event that caused the user agent to run the <a>process pending pointer capture</a> steps and fire the {{gotpointercapture}} and {{lostpointercapture}} events.</p>
                 </section>
 
                 <section>
                     <h4><dfn>Process pending pointer capture</dfn></h4>
-                    <p>The [=user agent=] MUST run the following steps when <a>implicitly releasing pointer capture</a> as well as when firing Pointer Events that are not {{GlobalEventHandlers/gotpointercapture}} or {{GlobalEventHandlers/lostpointercapture}}.</p>
+                    <p>The [=user agent=] MUST run the following steps when <a>implicitly releasing pointer capture</a> as well as when firing Pointer Events that are not {{gotpointercapture}} or {{lostpointercapture}}.</p>
                     <ol>
-                        <li>If the <a>pointer capture target override</a> for this pointer is set and is not equal to the <a>pending pointer capture target override</a>, then fire a pointer event named {{GlobalEventHandlers/lostpointercapture}} at the <a>pointer capture target override</a> node.
+                        <li>If the <a>pointer capture target override</a> for this pointer is set and is not equal to the <a>pending pointer capture target override</a>, then fire a pointer event named {{lostpointercapture}} at the <a>pointer capture target override</a> node.
                         </li>
-                        <li>If the <a>pending pointer capture target override</a> for this pointer is set and is not equal to the <a>pointer capture target override</a>, then fire a pointer event named {{GlobalEventHandlers/gotpointercapture}} at the <a>pending pointer capture target override</a>.
+                        <li>If the <a>pending pointer capture target override</a> for this pointer is set and is not equal to the <a>pointer capture target override</a>, then fire a pointer event named {{gotpointercapture}} at the <a>pending pointer capture target override</a>.
                         </li>
                         <li>Set the <dfn>pointer capture target override</dfn> to the <a>pending pointer capture target override</a>, if set. Otherwise, clear the <a>pointer capture target override</a>.</li>
                     </ol>
                     <div class="note">
-                        <p>As defined in the section for <a><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</a>, even after the {{GlobalEventHandlers/lostpointercapture}} event has been dispatched,
+                        <p>As defined in the section for <a><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</a>, even after the {{lostpointercapture}} event has been dispatched,
                         the corresponding <code>click</code>, <code>auxclick</code> or <code>contextmenu</code> event, if any, would still be dispatched to the capturing target.</p>
                     </div>
                 </section>
@@ -603,9 +603,9 @@ interface PointerEvent : MouseEvent {
 
                     <p>The [=user agent=] MUST run the following steps to <a>suppress a pointer event stream</a>:</p>
                     <ul>
-                        <li>Fire a {{GlobalEventHandlers/pointercancel}} event.</li>
-                        <li>Fire a {{GlobalEventHandlers/pointerout}} event.</li>
-                        <li>Fire a {{GlobalEventHandlers/pointerleave}} event.</li>
+                        <li>Fire a {{pointercancel}} event.</li>
+                        <li>Fire a {{pointerout}} event.</li>
+                        <li>Fire a {{pointerleave}} event.</li>
                         <li><a>Implicitly release the pointer capture</a> if the pointer is currently captured.</li>
                     </ul>
                 </section>
@@ -613,8 +613,8 @@ interface PointerEvent : MouseEvent {
 
             <section>
                 <h3><dfn data-lt="events-from-layout-changes">Boundary events caused by layout changes</dfn></h3>
-                <p>A pointing device that moved relative to the screen surface or underwent some change in any of its properties fires various events as defined in <a>Pointer Event types</a>.  For a stationary pointing device (that neither moved relative to the screen surface nor underwent any change in any properties), the [=user agent=] MUST fire certain boundary events after a layout change that affected the <a>hit test</a> target for the pointer, see {{GlobalEventHandlers/pointerover}}, {{GlobalEventHandlers/pointerenter}}, {{GlobalEventHandlers/pointerout}} and {{GlobalEventHandlers/pointerleave}} for details.  The [=user agent=] MAY delay the firing of these boundary events because of performance reasons (e.g. to avoid too many hit-tests or layout changes caused by boundary event listeners).</p>
-                <div class="note">A stationary pointing device (that neither moved relative to the screen surface nor underwent any change in any properties) never fires a {{GlobalEventHandlers/pointermove}} event.</div>
+                <p>A pointing device that moved relative to the screen surface or underwent some change in any of its properties fires various events as defined in <a>Pointer Event types</a>.  For a stationary pointing device (that neither moved relative to the screen surface nor underwent any change in any properties), the [=user agent=] MUST fire certain boundary events after a layout change that affected the <a>hit test</a> target for the pointer, see {{pointerover}}, {{pointerenter}}, {{pointerout}} and {{pointerleave}} for details.  The [=user agent=] MAY delay the firing of these boundary events because of performance reasons (e.g. to avoid too many hit-tests or layout changes caused by boundary event listeners).</p>
+                <div class="note">A stationary pointing device (that neither moved relative to the screen surface nor underwent any change in any properties) never fires a {{pointermove}} event.</div>
             </section>
 
             <section>
@@ -842,12 +842,11 @@ function tilt2spherical(tiltX, tiltY) {
 
 			    <ol class="algorithm">
                     <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
-			<p class="note">
-			Unlike mousedown events,
-			<a href="https://w3c.github.io/pointerevents/#the-pointerdown-event">pointerdown</a>
-			events are not nested when multiple buttons are pressed.
-			The MouseEvent is passed so that the fields can be copied into the PointerEvent.
-			</p>
+			        <p class="note">
+			            Unlike <code>mousedown</code> events, {{pointerdown}}
+			            events are not nested when multiple buttons are pressed.
+			            The {{MouseEvent}} is passed so that the fields can be copied into the PointerEvent.
+			        </p>
                     </li>
 			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|
 			        <li>Set pointerevent attributes
@@ -873,11 +872,9 @@ function tilt2spherical(tiltX, tiltY) {
 
 			    <ol class="algorithm">
                     <li>Let |mouseout|, the corresponding mouseout {{MouseEvent}}
-
-
-			<p class="ednote">
-			Unlike mouseup events, {{GlobalEventHandlers/pointerup}} events are not nested when multiple buttons are pressed. The MouseEvent is passed so that the fields can be copied into the PointerEvent.
-			</p>
+			        <p class="note">
+			            Unlike <code>mouseup</code> events, {{pointerup}} events are not nested when multiple buttons are pressed. The {{MouseEvent}} is passed so that the fields can be copied into the PointerEvent.
+			        </p>
                     </li>
 			        <li>Let |pointerout| be the result of [=creating PointerEvent from MouseEvent=] with "pointerout" and |mouseout|
 			        <li>Set pointerevent attributes
@@ -895,125 +892,125 @@ function tilt2spherical(tiltX, tiltY) {
         <section>
             <h2><dfn>Pointer Event types</dfn></h2>
             <p>Below are the event types defined in this specification.</p>
-            <p>In the case of the <a>primary pointer</a>, these events (with the exception of {{GlobalEventHandlers/gotpointercapture}} and {{GlobalEventHandlers/lostpointercapture}}) may also fire <a>compatibility mouse events</a>.</p>
+            <p>In the case of the <a>primary pointer</a>, these events (with the exception of {{gotpointercapture}} and {{lostpointercapture}}) may also fire <a>compatibility mouse events</a>.</p>
             <section>
-                <h3>The <dfn class='export' data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointerover</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerover}} when any of the following occurs:</p>
+                <h3>The <dfn class="export" data-dfn-type="event">pointerover</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerover}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved into an element.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element to move underneath an uncaptured pointer of a stationary pointing device.</li>
-                    <li>Before the user agent fires a {{GlobalEventHandlers/pointerdown}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{GlobalEventHandlers/pointerdown}}).</li>
+                    <li>Before the user agent fires a {{pointerdown}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{pointerdown}}).</li>
                 </ul>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointerenter</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerenter}} when any of the following occurs:</p>
+                <h3>The <dfn class="export" data-dfn-type="event">pointerenter</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerenter}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved into an element or one of its descendants.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element or one of its descendants to move underneath an uncaptured pointer of a stationary pointing device.</li>
-                    <li>Before the user agent fires a {{GlobalEventHandlers/pointerdown}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{GlobalEventHandlers/pointerdown}}).</li>
+                    <li>Before the user agent fires a {{pointerdown}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{pointerdown}}).</li>
                 </ul>
-                <div class="note">This event type is similar to {{GlobalEventHandlers/pointerover}} but with two differences: {{GlobalEventHandlers/pointerenter}} does not bubble, and its dispatch considers the <a>hit test</a> boundaries of even descendant elements.</div>
-                <div class="note">There are similarities between this event type, the <code>mouseenter</code> event described in [[UIEVENTS]], and the CSS <code>:hover</code> pseudo-class described in [[CSS21]]. See also the {{GlobalEventHandlers/pointerleave}} event.</div>
+                <div class="note">This event type is similar to {{pointerover}} but with two differences: {{pointerenter}} does not bubble, and its dispatch considers the <a>hit test</a> boundaries of even descendant elements.</div>
+                <div class="note">There are similarities between this event type, the <code>mouseenter</code> event described in [[UIEVENTS]], and the CSS <code>:hover</code> pseudo-class described in [[CSS21]]. See also the {{pointerleave}} event.</div>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointerdown</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerdown}} when a pointer enters the <a>active buttons state</a>. For mouse, this is when the device transitions from no buttons depressed to at least one button depressed. For touch, this is when physical contact is made with the <a>digitizer</a>. For pen, this is when the pen either makes physical contact with the digitizer without any button depressed, or transitions from no buttons depressed to at least one button depressed while hovering.</p>
-                <div class="note">For mouse (or other multi-button pointer devices), this means {{GlobalEventHandlers/pointerdown}} and {{GlobalEventHandlers/pointerup}} are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a>chorded buttons</a> for more information.</div>
-                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the [=user agent=] MUST also <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerover}} followed by a pointer event named {{GlobalEventHandlers/pointerenter}} prior to dispatching the {{GlobalEventHandlers/pointerdown}} event.</p>
-                <div class="note">Authors can prevent the firing of certain <a>compatibility mouse events</a> by canceling the {{GlobalEventHandlers/pointerdown}} event (if the <code>isPrimary</code> property is <code>true</code>). This sets the <code>PREVENT MOUSE EVENT</code> flag on the pointer. Note, however, that this does not prevent the <code>mouseover</code>, <code>mouseenter</code>, <code>mouseout</code>, or <code>mouseleave</code> events from firing.</div>
+                <h3>The <dfn data-dfn-type="event">pointerdown</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerdown}} when a pointer enters the <a>active buttons state</a>. For mouse, this is when the device transitions from no buttons depressed to at least one button depressed. For touch, this is when physical contact is made with the <a>digitizer</a>. For pen, this is when the pen either makes physical contact with the digitizer without any button depressed, or transitions from no buttons depressed to at least one button depressed while hovering.</p>
+                <div class="note">For mouse (or other multi-button pointer devices), this means {{pointerdown}} and {{pointerup}} are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a>chorded buttons</a> for more information.</div>
+                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the [=user agent=] MUST also <a>fire a pointer event</a> named {{pointerover}} followed by a pointer event named {{pointerenter}} prior to dispatching the {{pointerdown}} event.</p>
+                <div class="note">Authors can prevent the firing of certain <a>compatibility mouse events</a> by canceling the {{pointerdown}} event (if the <code>isPrimary</code> property is <code>true</code>). This sets the <code>PREVENT MOUSE EVENT</code> flag on the pointer. Note, however, that this does not prevent the <code>mouseover</code>, <code>mouseenter</code>, <code>mouseout</code>, or <code>mouseleave</code> events from firing.</div>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointermove</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointermove}} when a pointer changes any properties that don't fire
-                {{GlobalEventHandlers/pointerdown}} or {{GlobalEventHandlers/pointerup}} events. This includes any changes to coordinates, pressure, tangential pressure,
+                <h3>The <dfn data-dfn-type="event">pointermove</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointermove}} when a pointer changes any properties that don't fire
+                {{pointerdown}} or {{pointerup}} events. This includes any changes to coordinates, pressure, tangential pressure,
                 tilt, twist, contact geometry (<code>width</code> and <code>height</code>) or <a>chorded buttons</a>.</p>
-                <p>User agents MAY delay dispatch of the {{GlobalEventHandlers/pointermove}} event (for instance, for performance reasons).
-                The <a>coalesced events</a> information will be exposed via the{{PointerEvent/getCoalescedEvents}} method for the single dispatched {{GlobalEventHandlers/pointermove}} event.
+                <p>User agents MAY delay dispatch of the {{pointermove}} event (for instance, for performance reasons).
+                The <a>coalesced events</a> information will be exposed via the{{PointerEvent/getCoalescedEvents}} method for the single dispatched {{pointermove}} event.
                 The final coordinates of such events should be used for finding the target of the event.</p>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointerrawupdate</dfn> event</h3>
+                <h3>The <dfn data-dfn-type="event">pointerrawupdate</dfn> event</h3>
                 <p>The [=user agent=] MUST <a>fire a pointer event</a>
-                named {{GlobalEventHandlers/pointerrawupdate}}, and only do so within a [=secure context=], when a pointer changes any properties that don't fire
+                named {{pointerrawupdate}}, and only do so within a [=secure context=], when a pointer changes any properties that don't fire
                 <code>pointerdown</code> or <code>pointerup</code> events.  See <code>pointermove</code> event for a list of such properties.</p>
-                <p>In contrast with {{GlobalEventHandlers/pointermove}}, user agents SHOULD dispatch {{GlobalEventHandlers/pointerrawupdate}} events as soon as possible
+                <p>In contrast with {{pointermove}}, user agents SHOULD dispatch {{pointerrawupdate}} events as soon as possible
                 and as frequently as the JavaScript can handle the events.</p>
-                <p>The <code>target</code> of {{GlobalEventHandlers/pointerrawupdate}} events might be different from the {{GlobalEventHandlers/pointermove}} events
-                due to the fact that {{GlobalEventHandlers/pointermove}} events might get delayed or coalesced, and the final position of the event
+                <p>The <code>target</code> of {{pointerrawupdate}} events might be different from the {{pointermove}} events
+                due to the fact that {{pointermove}} events might get delayed or coalesced, and the final position of the event
                 which is used for finding the <code>target</code> could be different from its coalesced events.</p>
-                <p>Note that if there is already another {{GlobalEventHandlers/pointerrawupdate}} with the same {{PointerEvent/pointerId}} that hasn't been dispatched
+                <p>Note that if there is already another {{pointerrawupdate}} with the same {{PointerEvent/pointerId}} that hasn't been dispatched
                 in the [=event loop=], the
-                [=user agent=] MAY coalesce the new {{GlobalEventHandlers/pointerrawupdate}} with that event instead of creating a new [=task=].
-                This may cause {{GlobalEventHandlers/pointerrawupdate}} to have coalesced events, and
-                they will all be delivered as <a>coalesced events</a> of one {{GlobalEventHandlers/pointerrawupdate}} event as soon as
+                [=user agent=] MAY coalesce the new {{pointerrawupdate}} with that event instead of creating a new [=task=].
+                This may cause {{pointerrawupdate}} to have coalesced events, and
+                they will all be delivered as <a>coalesced events</a> of one {{pointerrawupdate}} event as soon as
                 the event is processed in the [=event loop=].
                 See{{PointerEvent/getCoalescedEvents}} for more information.</p>
-                <p>In terms of ordering of {{GlobalEventHandlers/pointerrawupdate}} and {{GlobalEventHandlers/pointermove}},
-                if the user agent received an update from the platform that causes both {{GlobalEventHandlers/pointerrawupdate}} and {{GlobalEventHandlers/pointermove}} events,
-                then the [=user agent=] MUST dispatch the {{GlobalEventHandlers/pointerrawupdate}} event before the corresponding {{GlobalEventHandlers/pointermove}}.</p>
-                <p>Other than the <code>target</code>, the concatenation of coalesced events lists of all dispatched {{GlobalEventHandlers/pointerrawupdate}} events
-                since the last {{GlobalEventHandlers/pointermove}} event is the same as the coalesced events of the next {{GlobalEventHandlers/pointermove}} event in terms of the other event attributes.
-                The attributes of {{GlobalEventHandlers/pointerrawupdate}} are mostly the same as {{GlobalEventHandlers/pointermove}}, with the exception of
-                <code>cancelable</code> which MUST be false for {{GlobalEventHandlers/pointerrawupdate}}.</p>
-                <p>User agents SHOULD not fire <a>compatibility mouse events</a> for {{GlobalEventHandlers/pointerrawupdate}}.</p>
-                <div class="note">Adding listeners for the {{GlobalEventHandlers/pointerrawupdate}} event might negatively impact the performance of the web page, depending on the implementation of the user agent.
+                <p>In terms of ordering of {{pointerrawupdate}} and {{pointermove}},
+                if the user agent received an update from the platform that causes both {{pointerrawupdate}} and {{pointermove}} events,
+                then the [=user agent=] MUST dispatch the {{pointerrawupdate}} event before the corresponding {{pointermove}}.</p>
+                <p>Other than the <code>target</code>, the concatenation of coalesced events lists of all dispatched {{pointerrawupdate}} events
+                since the last {{pointermove}} event is the same as the coalesced events of the next {{pointermove}} event in terms of the other event attributes.
+                The attributes of {{pointerrawupdate}} are mostly the same as {{pointermove}}, with the exception of
+                <code>cancelable</code> which MUST be false for {{pointerrawupdate}}.</p>
+                <p>User agents SHOULD not fire <a>compatibility mouse events</a> for {{pointerrawupdate}}.</p>
+                <div class="note">Adding listeners for the {{pointerrawupdate}} event might negatively impact the performance of the web page, depending on the implementation of the user agent.
                 For most use cases the other pointerevent types should suffice.
-                A {{GlobalEventHandlers/pointerrawupdate}} listener should only be added if JavaScript needs high frequency events and can handle them just as fast.
+                A {{pointerrawupdate}} listener should only be added if JavaScript needs high frequency events and can handle them just as fast.
                 In these cases, there is probably no need to listen to other types of pointer events.</div>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-event-type="event">pointerup</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerup}} when a pointer leaves the <a>active buttons state</a>. For mouse, this is when the device transitions from at least one button depressed to no buttons depressed. For touch, this is when physical contact is removed from the <a>digitizer</a>. For pen, this is when the pen is removed from the physical contact with the digitizer while no button is depressed, or transitions from at least one button depressed to no buttons depressed while hovering.</p>
-                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the [=user agent=] MUST also <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerout}} followed by a pointer event named {{GlobalEventHandlers/pointerleave}} after dispatching the {{GlobalEventHandlers/pointerup}} event.</p>
-                <p>All {{GlobalEventHandlers/pointerup}} events have a <code>pressure</code> value of <code>0</code>.</p>
+                <h3>The <dfn data-event-type="event">pointerup</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerup}} when a pointer leaves the <a>active buttons state</a>. For mouse, this is when the device transitions from at least one button depressed to no buttons depressed. For touch, this is when physical contact is removed from the <a>digitizer</a>. For pen, this is when the pen is removed from the physical contact with the digitizer while no button is depressed, or transitions from at least one button depressed to no buttons depressed while hovering.</p>
+                <p>For input <a href=#mapping-for-devices-that-do-not-support-hover>devices that do not support hover</a>, the [=user agent=] MUST also <a>fire a pointer event</a> named {{pointerout}} followed by a pointer event named {{pointerleave}} after dispatching the {{pointerup}} event.</p>
+                <p>All {{pointerup}} events have a <code>pressure</code> value of <code>0</code>.</p>
                 <p>The [=user agent=] MUST also <a>implicitly release the pointer capture</a> if the pointer is currently captured.</p>
-                <div class="note">For mouse (or other multi-button pointer devices), this means {{GlobalEventHandlers/pointerdown}} and {{GlobalEventHandlers/pointerup}} are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a>chorded buttons</a> for more information.</div>
+                <div class="note">For mouse (or other multi-button pointer devices), this means {{pointerdown}} and {{pointerup}} are not fired for all of the same circumstances as <code>mousedown</code> and <code>mouseup</code>. See <a>chorded buttons</a> for more information.</div>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointercancel</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointercancel}} when it detects a scenario to <a>suppress a pointer event stream</a>.</p>
-                <p>The values of the following properties of the {{GlobalEventHandlers/pointercancel}} event MUST match the values of the last dispatched pointer event with the same {{PointerEvent/pointerId}}: <code>width</code>, <code>height</code>, <code>pressure</code>, <code>tangentialPressure</code>, <code>tiltX</code>, <code>tiltY</code>, <code>twist</code>, <code>altitudeAngle</code>, <code>azimuthAngle</code>, <code>pointerType</code>, <code>isPrimary</code>, and the coordinates inherited from [[UIEVENTS]]. The <code>coalescedEvents</code> and <code>predictedEvents</code> lists in the {{GlobalEventHandlers/pointercancel}} event MUST be empty, and the event's {{Event/cancelable}} attribute MUST be false.</p>
+                <h3>The <dfn data-dfn-type="event">pointercancel</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointercancel}} when it detects a scenario to <a>suppress a pointer event stream</a>.</p>
+                <p>The values of the following properties of the {{pointercancel}} event MUST match the values of the last dispatched pointer event with the same {{PointerEvent/pointerId}}: <code>width</code>, <code>height</code>, <code>pressure</code>, <code>tangentialPressure</code>, <code>tiltX</code>, <code>tiltY</code>, <code>twist</code>, <code>altitudeAngle</code>, <code>azimuthAngle</code>, <code>pointerType</code>, <code>isPrimary</code>, and the coordinates inherited from [[UIEVENTS]]. The <code>coalescedEvents</code> and <code>predictedEvents</code> lists in the {{pointercancel}} event MUST be empty, and the event's {{Event/cancelable}} attribute MUST be false.</p>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointerout</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerout}} when any of the following occurs:</p>
+                <h3>The <dfn data-dfn-type="event">pointerout</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerout}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved out of an element.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element to move away from underneath an uncaptured pointer of a stationary pointing device.</li>
-                    <li>After the user agent fires a {{GlobalEventHandlers/pointerup}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{GlobalEventHandlers/pointerup}}).</li>
+                    <li>After the user agent fires a {{pointerup}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{pointerup}}).</li>
                     <li>The user agent has detected a scenario to <a>suppress a pointer event stream</a>.</li>
                 </ul>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">pointerleave</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/pointerleave}} when any of the following occurs:</p>
+                <h3>The <dfn data-dfn-type="event">pointerleave</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{pointerleave}} when any of the following occurs:</p>
                 <ul>
                     <li>The step to <a>determine the target</a> of a pointer detects that the pointer has moved out of an element and all of its descendants.</li>
                     <li>A <a data-lt="events-from-layout-changes">layout change</a> causes the <a>hit test</a> boundaries of an element and all of its descendants to move away from underneath an uncaptured pointer of a stationary pointing device.</li>
-                    <li>After the user agent fires the {{GlobalEventHandlers/pointerup}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{GlobalEventHandlers/pointerup}}).</li>
+                    <li>After the user agent fires the {{pointerup}} event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (see {{pointerup}}).</li>
                     <li>The user agent has detected a scenario to <a>suppress a pointer event stream</a>.</li>
                 </ul>
-                <div class="note">This event type is similar to {{GlobalEventHandlers/pointerout}} but with two differences: {{GlobalEventHandlers/pointerleave}} does not bubble, and its dispatch considers the <a>hit test</a> boundaries of even descendant elements.</div>
-                <div class="note">There are similarities between this event type, the <code>mouseleave</code> event described in [[UIEVENTS]], and the CSS <code>:hover</code> pseudo-class described in [[CSS21]]. See also the {{GlobalEventHandlers/pointerenter}} event.</div>
+                <div class="note">This event type is similar to {{pointerout}} but with two differences: {{pointerleave}} does not bubble, and its dispatch considers the <a>hit test</a> boundaries of even descendant elements.</div>
+                <div class="note">There are similarities between this event type, the <code>mouseleave</code> event described in [[UIEVENTS]], and the CSS <code>:hover</code> pseudo-class described in [[CSS21]]. See also the {{pointerenter}} event.</div>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">gotpointercapture</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/gotpointercapture}} when an element receives pointer capture. This event is fired at the element that is receiving pointer capture. Subsequent events for that pointer will be fired at this element. See the <a>setting pointer capture</a> and <a>process pending pointer capture</a> sections.</p>
+                <h3>The <dfn data-dfn-type="event">gotpointercapture</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{gotpointercapture}} when an element receives pointer capture. This event is fired at the element that is receiving pointer capture. Subsequent events for that pointer will be fired at this element. See the <a>setting pointer capture</a> and <a>process pending pointer capture</a> sections.</p>
             </section>
 
             <section>
-                <h3>The <dfn data-dfn-for="GlobalEventHandlers" data-dfn-type="event">lostpointercapture</dfn> event</h3>
-                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{GlobalEventHandlers/lostpointercapture}} after pointer capture is released for a pointer. This event MUST be fired prior to any subsequent events for the pointer after capture was released. This event is fired at the element from which pointer capture was removed. All subsequent events for the pointer except <a><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</a> follow normal hit testing mechanisms (out of scope for this specification) for determining the event target. See the <a>releasing pointer capture</a>, <a>implicit release of pointer capture</a>, and <a>process pending pointer capture</a> sections.</p>
+                <h3>The <dfn data-dfn-type="event">lostpointercapture</dfn> event</h3>
+                <p>The [=user agent=] MUST <a>fire a pointer event</a> named {{lostpointercapture}} after pointer capture is released for a pointer. This event MUST be fired prior to any subsequent events for the pointer after capture was released. This event is fired at the element from which pointer capture was removed. All subsequent events for the pointer except <a><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</a> follow normal hit testing mechanisms (out of scope for this specification) for determining the event target. See the <a>releasing pointer capture</a>, <a>implicit release of pointer capture</a>, and <a>process pending pointer capture</a> sections.</p>
             </section>
 
             <section>
@@ -1049,7 +1046,7 @@ function tilt2spherical(tiltX, tiltY) {
                             <p>Let |event| be the <code>click</code>, <code>auxclick</code> or <code>contextmenu</code> event being dispatched, and |userEvent| be the user interaction event that caused the firing of |event|.</p>
                             <div class="note">
                                 <p>Event |userEvent| could be a non-<code>PointerEvent</code>; for example, it is a <code>KeyboardEvent</code> when a <code>click</code> event dispatch is caused by hitting the spacebar on a checkbox element.</p>
-                                <p>When |userEvent| is a <code>PointerEvent</code>, |userEvent| is a {{GlobalEventHandlers/pointerup}} for a <code>click</code> or <code>auxclick</code> event, and either a {{GlobalEventHandlers/pointerdown}} or a {{GlobalEventHandlers/pointerup}} event (depending on native platform convention) for a <code>contextmenu</code> event.</p>
+                                <p>When |userEvent| is a <code>PointerEvent</code>, |userEvent| is a {{pointerup}} for a <code>click</code> or <code>auxclick</code> event, and either a {{pointerdown}} or a {{pointerup}} event (depending on native platform convention) for a <code>contextmenu</code> event.</p>
                             </div>
                         </li>
 
@@ -1065,7 +1062,7 @@ function tilt2spherical(tiltX, tiltY) {
 
                         <li>
                             <p>Dispatch |event| to |target| following the [[UIEVENTS]] spec.</p>
-                            <div class="note">If |userEvent| was captured, |event| is dispatched to the capturing target of |userEvent| even though the {{GlobalEventHandlers/lostpointercapture}} event with the same {{PointerEvent/pointerId}} has been dispatched already.</div>
+                            <div class="note">If |userEvent| was captured, |event| is dispatched to the capturing target of |userEvent| even though the {{lostpointercapture}} event with the same {{PointerEvent/pointerId}} has been dispatched already.</div>
                         </li>
                     </ol>
                 </section>
@@ -1096,7 +1093,7 @@ partial interface Element {
                 <dt><dfn>hasPointerCapture</dfn></dt>
                 <dd>
                     <p>Indicates whether the element on which this method is invoked has <a>pointer capture</a> for the pointer identified by the argument {{PointerEvent/pointerId}}. In particular, returns <code>true</code> if the <a>pending pointer capture target override</a> for {{PointerEvent/pointerId}} is set to the element on which this method is invoked, and <code>false</code> otherwise.</p>
-                    <div class="note">This method will return true immediately after a call to <a>setPointerCapture()</a>, even though that element will not yet have received a {{GlobalEventHandlers/gotpointercapture}} event. As a result it can be useful for detecting <a>implicit pointer capture</a> from inside of a {{GlobalEventHandlers/pointerdown}} event listener.</div>
+                    <div class="note">This method will return true immediately after a call to <a>setPointerCapture()</a>, even though that element will not yet have received a {{gotpointercapture}} event. As a result it can be useful for detecting <a>implicit pointer capture</a> from inside of a {{pointerdown}} event listener.</div>
                 </dd>
             </dl>
         </div>
@@ -1124,49 +1121,49 @@ partial interface mixin GlobalEventHandlers {
             <dl data-dfn-for="GlobalEventHandlers" data-link-for="GlobalEventHandlers">
                 <dt><dfn>onpointerover</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerover}} event type.
+                    The [=event handler IDL attribute=] for the {{pointerover}} event type.
                 </dd>
                 <dt><dfn>onpointerenter</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the <code>pointerenter</code> event type.
+                    The [=event handler IDL attribute=] for the {{pointerenter}} event type.
                 </dd>
                 <dt><dfn>onpointerdown</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerdown}} event type.
+                    The [=event handler IDL attribute=] for the {{pointerdown}} event type.
                 </dd>
                 <dt><dfn>onpointermove</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointermove}} event type.
+                    The [=event handler IDL attribute=] for the {{pointermove}} event type.
                 </dd>
                 <dt><dfn>onpointerrawupdate</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerrawupdate}} event type.
+                    The [=event handler IDL attribute=] for the {{pointerrawupdate}} event type.
                 </dd>
                 <dt><dfn>onpointerup</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerup}} event type.
+                    The [=event handler IDL attribute=] for the {{pointerup}} event type.
                 </dd>
                 <dt><dfn>onpointercancel</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointercancel}} event type.
+                    The [=event handler IDL attribute=] for the {{pointercancel}} event type.
                 </dd>
 
                 <dt><dfn>onpointerout</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerout}} event type.
+                    The [=event handler IDL attribute=] for the {{pointerout}} event type.
                 </dd>
 
                 <dt><dfn>onpointerleave</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/pointerleave}} event type.
+                    The [=event handler IDL attribute=] for the {{pointerleave}} event type.
                 </dd>
                 <dt><dfn>ongotpointercapture</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/gotpointercapture}} event type.
+                    The [=event handler IDL attribute=] for the {{gotpointercapture}} event type.
                 </dd>
                 <dt><dfn>onlostpointercapture</dfn></dt>
                 <dd>
-                    The [=event handler IDL attribute=] for the {{GlobalEventHandlers/lostpointercapture}} event type.
+                    The [=event handler IDL attribute=] for the {{lostpointercapture}} event type.
                 </dd>
             </dl>
         </div>
@@ -1230,8 +1227,8 @@ partial interface Navigator {
             <p>Right before starting to pan or zoom, the [=user agent=] MUST <a>suppress a pointer event stream</a> if all of the following conditions are true:</p>
             <ul>
                 <li>The user agent has determined (via methods out of scope for this specification) that a direct manipulation interaction is to be consumed for panning or zooming,</li>
-                <li>a {{GlobalEventHandlers/pointerdown}} event has been sent for the pointer, and</li>
-                <li>a {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointercancel}} event (following the above mentioned {{GlobalEventHandlers/pointerdown}}) has not yet been sent for the pointer.</li>
+                <li>a {{pointerdown}} event has been sent for the pointer, and</li>
+                <li>a {{pointerup}} or {{pointercancel}} event (following the above mentioned {{pointerdown}}) has not yet been sent for the pointer.</li>
             </ul>
 
             <div class="note">Some user agents implement complex gestures for behaviors that involve a series of separate discrete gestures, but which are all treated as part of a single continuous gesture. For example, consider a "fling to scroll" gesture on a touchscreen: a user starts panning the document with a rapid finger movement, lifts the finger from the touchscreen, and the document continues panning with simulated inertia. While the document is still moving, the user may place their finger on the touchscreen and execute another "fling" to provide further momentum for the panning, or counteract the current panning to slow it down, stop panning altogether, or reverse the direction of the panning. As this specification does not normatively define how gestures and behaviors are implemented, it is left up to the user agent to decide whether or not the second touch (before it is interpreted as a second "fling" or counteraction of the current panning) fires pointer events or not.</div>
@@ -1246,7 +1243,7 @@ partial interface Navigator {
                 <li>A direct manipulation interaction for panning and zooming <dfn data-lt="conforming-touch-behavior">conforms to an element's <code>touch-action</code></dfn> if the behavior is allowed in the coordinate space of the element. Note that if CSS transforms have been applied, the element's coordinate space may differ from the screen coordinate in a way that affects the conformity here; for example, the X axis of an element rotated by 90 degrees with respect to the screen will be parallel to the Y-axis of the screen coordinate.</li>
                 <li>A direct manipulation interaction for panning is supported if it <a data-lt="conforming-touch-behavior">conforms</a> to the <code>touch-action</code> property of each element between the hit tested element and its nearest inclusive ancestor that is a [=scroll container=] (as defined in [[CSS-OVERFLOW-3]]).</li>
                 <li>A direct manipulation interaction for zooming is supported if it <a data-lt="conforming-touch-behavior">conforms</a> to the <code>touch-action</code> property of each element between the hit tested element and the <code>document</code> element of the [=top-level browsing context=] (as defined in [[HTML]]).</li>
-                <li>Once panning or zooming has been started, and the user agent has already determined whether or not the gesture should be handled as a user agent direct manipulation behavior, any changes to the relevant <code>touch-action</code> value will be ignored for the duration of the action. For instance, programmatically changing the <code>touch-action</code> value for an element from <code>auto</code> to <code>none</code> as part of a {{GlobalEventHandlers/pointerdown}} handler script will not result in the user agent aborting or suppressing any of the pan or zoom behavior for that input for as long as that pointer is active.</li>
+                <li>Once panning or zooming has been started, and the user agent has already determined whether or not the gesture should be handled as a user agent direct manipulation behavior, any changes to the relevant <code>touch-action</code> value will be ignored for the duration of the action. For instance, programmatically changing the <code>touch-action</code> value for an element from <code>auto</code> to <code>none</code> as part of a {{pointerdown}} handler script will not result in the user agent aborting or suppressing any of the pan or zoom behavior for that input for as long as that pointer is active.</li>
                 <li>Similarly, in the case of the various <code>touch-action</code> values of <code>pan-*</code>, once the user agent has determined whether to handle a gesture directly or not at the start of the gesture, a subsequent change in the direction of the same gesture SHOULD be ignored by the user agent for as long as that pointer is active. For instance, if an element has been set to <code>touch-action: pan-y</code> (meaning that only vertical panning is handled by the user agent), and a touch gesture starts off horizontally, no vertical panning should occur if the user changes the direction of their gesture to be vertical while their finger is still touching the screen.</li>
             </ul>
 
@@ -1330,7 +1327,7 @@ partial interface Navigator {
             <p>Pointer capture allows the events for a particular pointer (including any <a>compatibility mouse events</a>) to be retargeted to a particular element other than the normal <a>hit test</a> result of the pointer's location. This is useful in scenarios like a custom slider control (e.g. similar to the [[HTML]] <code>&lt;input type="range"&gt;</code> control). Pointer capture can be set on the slider thumb element, allowing the user to slide the control back and forth even if the pointer slides off of the thumb.</p>
             <figure id="figure_slider">
                 <img src="images/slider.png" alt="Custom Volume Slider">
-                <figcaption>Example of a custom slider control that chooses a value by sliding the thumb element back and forth. After {{GlobalEventHandlers/pointerdown}} on the thumb, pointer capture can be used to allow the user to slide the thumb even if the pointer drifts off of it.</figcaption>
+                <figcaption>Example of a custom slider control that chooses a value by sliding the thumb element back and forth. After {{pointerdown}} on the thumb, pointer capture can be used to allow the user to slide the thumb even if the pointer drifts off of it.</figcaption>
             </figure>
         </section>
 
@@ -1348,7 +1345,7 @@ partial interface Navigator {
                     the |element|'s [=Node/node document=] is not the <a>active document</a> of the |pointer|, then terminate these steps.</li>
                 <li>For the specified {{PointerEvent/pointerId}}, set the <dfn>pending pointer capture target override</dfn> to the {{Element}} on which this method was invoked.</li>
             </ol>
-            <div class="note">If a call to set or release a pointer capture is made while a previous set or release call is in a pending state (see <a>process pending pointer capture</a>), the second call overrides the first call if the second call is successful, otherwise the first call remains effective.  This is true for a failed attempt to release an <a>implicit pointer capture</a> at a {{GlobalEventHandlers/pointerdown}} listener.</div>
+            <div class="note">If a call to set or release a pointer capture is made while a previous set or release call is in a pending state (see <a>process pending pointer capture</a>), the second call overrides the first call if the second call is successful, otherwise the first call remains effective.  This is true for a failed attempt to release an <a>implicit pointer capture</a> at a {{pointerdown}} listener.</div>
         </section>
 
         <section>
@@ -1364,17 +1361,17 @@ partial interface Navigator {
 
         <section>
             <h2><dfn>Implicit pointer capture</dfn></h2>
-            <p>Inputs that implement <a>direct manipulation</a> interactions for panning and zooming (such as touch or stylus on a touchscreen) SHOULD behave exactly as if {{Element/setPointerCapture}} was called on the target element just before the invocation of any {{GlobalEventHandlers/pointerdown}} listeners. The {{Element/hasPointerCapture}} API may be used (for instance, in a {{GlobalEventHandlers/pointerdown}} listener) to determine whether this has occurred. If {{Element/releasePointerCapture}} is not called for the pointer before the next pointer event is fired, then a {{GlobalEventHandlers/gotpointercapture}} event will be dispatched to the target (as normal) indicating that capture is active.</p>
+            <p>Inputs that implement <a>direct manipulation</a> interactions for panning and zooming (such as touch or stylus on a touchscreen) SHOULD behave exactly as if {{Element/setPointerCapture}} was called on the target element just before the invocation of any {{pointerdown}} listeners. The {{Element/hasPointerCapture}} API may be used (for instance, in a {{pointerdown}} listener) to determine whether this has occurred. If {{Element/releasePointerCapture}} is not called for the pointer before the next pointer event is fired, then a {{gotpointercapture}} event will be dispatched to the target (as normal) indicating that capture is active.</p>
             <div class="note">This is a breaking change from [[PointerEvents]], but does not impact the vast majority of existing content. In addition to matching typical platform UX conventions, this design for implicit capture enables user agents to make a performance optimization which prevents the need to invoke hit-testing on touch movement events without explicit developer opt-in (consistent with the performance properties of existing dominant native and web APIs for touch input).</div>
             <div class="note">In addition, user agents may implement implicit pointer capture behavior for all input devices on specific UI widgets such as input range controls (allowing some finger movement to stray outside of the form control itself during the interaction).</div>
         </section>
 
         <section>
             <h2><dfn data-lt="implicitly release the pointer capture|implicitly releasing pointer capture">Implicit release of pointer capture</dfn></h2>
-            <p>Immediately after firing the {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointercancel}} events,
+            <p>Immediately after firing the {{pointerup}} or {{pointercancel}} events,
                 the [=user agent=] MUST clear the <a>pending pointer capture target override</a>
-                for the {{PointerEvent/pointerId}} of the {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointercancel}} event that was just dispatched,
-                and then run <a>process pending pointer capture</a> steps to fire {{GlobalEventHandlers/lostpointercapture}} if necessary.
+                for the {{PointerEvent/pointerId}} of the {{pointerup}} or {{pointercancel}} event that was just dispatched,
+                and then run <a>process pending pointer capture</a> steps to fire {{lostpointercapture}} if necessary.
                 After running <a>process pending pointer capture</a> steps,
                 if the pointer supports hover, [=user agent=] MUST also send corresponding boundary events necessary
                 to reflect the current position of the pointer with no capture.</p>
@@ -1383,7 +1380,7 @@ partial interface Navigator {
             <p>When the <a>pending pointer capture target override</a> is no longer [=connected=] [[DOM]],
                 the <a>pending pointer capture target override</a> node SHOULD be cleared.</p>
             <div class="note">
-                The previous two paragraphs result in a {{GlobalEventHandlers/lostpointercapture}} event
+                The previous two paragraphs result in a {{lostpointercapture}} event
                 corresponding to the captured pointer being fired at the document
                 during the next <a>Process pending pointer capture</a> after the capture node is removed.
             </div>
@@ -1400,11 +1397,11 @@ partial interface Navigator {
         <section>
             <h2><dfn>Coalesced events</dfn></h2>
 
-            <p>For performance reasons, user agents may choose not to send a {{GlobalEventHandlers/pointermove}}
+            <p>For performance reasons, user agents may choose not to send a {{pointermove}}
             event every time a <a>measurable property</a>
             (such as coordinates, pressure, tangential pressure, tilt, twist, or contact geometry)
             of a pointer is updated. Instead, they may coalesce (combine/merge) multiple changes into
-            a single {{GlobalEventHandlers/pointermove}} or {{GlobalEventHandlers/pointerrawupdate}} event. While
+            a single {{pointermove}} or {{pointerrawupdate}} event. While
             this approach helps in reducing the amount of event handling the [=user agent=] MUST perform,
             it will naturally reduce the granularity and fidelity when tracking a pointer position,
             particularly for fast and large movements. Using the
@@ -1417,17 +1414,17 @@ partial interface Navigator {
             <figure id="figure_coalesced">
                 <img src="images/coalesced-points.png" alt="Close-up view of a curve, showing coalesced and un-coalesced points">
                 <figcaption>Example of a curve in a drawing application — using only the coalesced
-                coordinates from {{GlobalEventHandlers/pointermove}} events (the grey dots), the curve is noticeably
+                coordinates from {{pointermove}} events (the grey dots), the curve is noticeably
                 angular and jagged; the same line drawn using the more granular points provided by
                 <code>getCoalescedEvents()</code> (the red circles) results in a smoother approximation
                 of the pointer movement.</figcaption>
             </figure>
 
             <p>A <a>PointerEvent</a> has an associated <dfn>coalesced events list</dfn> (a list of
-            zero or more <code>PointerEvent</code>s). For trusted {{GlobalEventHandlers/pointermove}} and
-            {{GlobalEventHandlers/pointerrawupdate}} events, the list is a sequence of all <code>PointerEvent</code>s
-            that were coalesced into this event. The "parent" trusted {{GlobalEventHandlers/pointermove}} and
-            {{GlobalEventHandlers/pointerrawupdate}} event represents an accumulation of these coalesced events,
+            zero or more <code>PointerEvent</code>s). For trusted {{pointermove}} and
+            {{pointerrawupdate}} events, the list is a sequence of all <code>PointerEvent</code>s
+            that were coalesced into this event. The "parent" trusted {{pointermove}} and
+            {{pointerrawupdate}} event represents an accumulation of these coalesced events,
             but may have additional processing (for example to align with the display refresh rate).
             As a result, the coalesced events lists for these events always contain at least one event.
             For all other trusted event types, it is an empty list. Untrusted events have their
@@ -1492,31 +1489,31 @@ partial interface Navigator {
             this specification.</div>
 
             <p>The order of all these dispatched events MUST match the actual order of the original events.
-            For example if a {{GlobalEventHandlers/pointerdown}} event causes the dispatch for the
-            coalesced {{GlobalEventHandlers/pointermove}} events the [=user agent=] MUST first dispatch one {{GlobalEventHandlers/pointermove}}
-            event with all those coalesced events of a {{PointerEvent/pointerId}} followed by the {{GlobalEventHandlers/pointerdown}} event.</p>
+            For example if a {{pointerdown}} event causes the dispatch for the
+            coalesced {{pointermove}} events the [=user agent=] MUST first dispatch one {{pointermove}}
+            event with all those coalesced events of a {{PointerEvent/pointerId}} followed by the {{pointerdown}} event.</p>
             <div class="note">
                 <p>Here is an example of the actual events happening with increasing {{Event/timeStamp}} values and the
                 events dispatched by the user agent:</p>
                 <table class="data">
                     <thead><tr><th>Actual events</th><th>Dispatched events</th> </tr></thead>
                     <tbody>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=1) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=1) w/ one coalesced event</td></tr>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=1) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=1) w/ one coalesced event</td></tr>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=1) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=1) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=1) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=1) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
                         <tr><td>pointer ({{PointerEvent/pointerId}}=1) button press</td><td>
-                        {{GlobalEventHandlers/pointermove}} ({{PointerEvent/pointerId}}=1) w/ two coalesced events<br>
-                        {{GlobalEventHandlers/pointermove}} ({{PointerEvent/pointerId}}=2) w/ four coalesced events<br>
-                        {{GlobalEventHandlers/pointerdown}} ({{PointerEvent/pointerId}}=1) w/ zero coalesced events<br>
+                        {{pointermove}} ({{PointerEvent/pointerId}}=1) w/ two coalesced events<br>
+                        {{pointermove}} ({{PointerEvent/pointerId}}=2) w/ four coalesced events<br>
+                        {{pointerdown}} ({{PointerEvent/pointerId}}=1) w/ zero coalesced events<br>
                         </td></tr>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
-                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{GlobalEventHandlers/pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
+                        <tr><td>pointer ({{PointerEvent/pointerId}}=2) coordinate change</td><td>{{pointerrawupdate}} ({{PointerEvent/pointerId}}=2) w/ one coalesced event</td></tr>
                         <tr><td>pointer ({{PointerEvent/pointerId}}=1) button release</td><td>
-                        {{GlobalEventHandlers/pointermove}} ({{PointerEvent/pointerId}}=2) w/ two coalesced events<br>
-                        {{GlobalEventHandlers/pointerup}} ({{PointerEvent/pointerId}}=1) w/ zero coalesced events<br>
+                        {{pointermove}} ({{PointerEvent/pointerId}}=2) w/ two coalesced events<br>
+                        {{pointerup}} ({{PointerEvent/pointerId}}=1) w/ zero coalesced events<br>
                         </td></tr>
                     </tbody>
                 </table>
@@ -1536,11 +1533,11 @@ partial interface Navigator {
 
             <figure id="figure_predicted">
                 <img src="images/predicted-points.png" alt="A line drawn using coalesced points, showing predicted future points">
-                <figcaption>Example of a line in a drawing application (the result of a drawing gesture from the bottom left to the top right), using the coalesced coordinates from {{GlobalEventHandlers/pointermove}} events, showing the user agent's predicted future points (the grey circles).</figcaption>
+                <figcaption>Example of a line in a drawing application (the result of a drawing gesture from the bottom left to the top right), using the coalesced coordinates from {{pointermove}} events, showing the user agent's predicted future points (the grey circles).</figcaption>
             </figure>
 
             <p>A <a>PointerEvent</a> has an associated <dfn>predicted events list</dfn> (a list of zero or more
-            <code>PointerEvent</code>s). For trusted {{GlobalEventHandlers/pointermove}} events, it is a sequence of
+            <code>PointerEvent</code>s). For trusted {{pointermove}} events, it is a sequence of
             <code>PointerEvent</code>s that the user agent predicts will follow the event in the future.
             For all other trusted event types, it is an empty list.
             Untrusted events have their <a>predicted events list</a> initialized to the value passed to the
@@ -1628,24 +1625,24 @@ window.addEventListener("pointermove", function(event) {
         <p>The compatibility mapping with mouse events is an OPTIONAL feature of this specification. User agents are encouraged to support the feature for best compatibility with existing legacy content.</p>
         <div class="note">
             <p>At a high level, compatibility mouse events are intended to be "interleaved" with their respective pointer events. However, this specific order is not mandatory, and user agents that implement compatibility mouse events MAY decide to delay or group the dispatch of mouse events, as long as their relative order is consistent.</p>
-            <p>Particularly in the case of touchscreen inputs, user agents MAY apply additional heuristics for gesture recognition (unless explicitly suppressed by authors through <a><code>touch-action</code></a>). During a sequence of events between a {{GlobalEventHandlers/pointerdown}} event and a {{GlobalEventHandlers/pointerup}} event, the gesture recognition may have to wait until the {{GlobalEventHandlers/pointerup}} event to detect or ignore a gesture. As a result the compatibility mouse events for the whole sequence may be dispatched together after the last {{GlobalEventHandlers/pointerup}} event, if the user agent determined that an interaction was not intended as a particular gesture. These specifics of user agent gesture recognition are not defined in this specification, and they may differ between implementations.</p>
+            <p>Particularly in the case of touchscreen inputs, user agents MAY apply additional heuristics for gesture recognition (unless explicitly suppressed by authors through <a><code>touch-action</code></a>). During a sequence of events between a {{pointerdown}} event and a {{pointerup}} event, the gesture recognition may have to wait until the {{pointerup}} event to detect or ignore a gesture. As a result the compatibility mouse events for the whole sequence may be dispatched together after the last {{pointerup}} event, if the user agent determined that an interaction was not intended as a particular gesture. These specifics of user agent gesture recognition are not defined in this specification, and they may differ between implementations.</p>
         </div>
         <p>Regardless of their support for compatibility mouse events, the user agents MUST always support the <code>click</code>, <code>auxclick</code> and <code>contextmenu</code> events because these events are of type <code>PointerEvent</code> and are therefore not <a>compatibility mouse events</a>. Calling <code>preventDefault</code> during a pointer event MUST NOT have an effect on whether <code>click</code>, <code>auxclick</code>, or <code>contextmenu</code> are fired or not.</p>
         <div class="note">
-            <p>The relative order of some of these high-level events (such as <code>contextmenu</code>, [=HTMLElement/focus=], [=HTMLElement/blur=]) with pointer events is undefined and varies between user agents. For example, in some user agents <code>contextmenu</code> will often follow a {{GlobalEventHandlers/pointerup}}, while in others it'll often precede a {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointercancel}}, and in some situations it may be fired without any corresponding pointer event (for instance, as a result of a keyboard interaction).</p>
+            <p>The relative order of some of these high-level events (such as <code>contextmenu</code>, [=HTMLElement/focus=], [=HTMLElement/blur=]) with pointer events is undefined and varies between user agents. For example, in some user agents <code>contextmenu</code> will often follow a {{pointerup}}, while in others it'll often precede a {{pointerup}} or {{pointercancel}}, and in some situations it may be fired without any corresponding pointer event (for instance, as a result of a keyboard interaction).</p>
             <p>In addition, user agents may apply their own heuristics to determine whether or not a <code>click</code>, <code>auxclick</code>, or <code>contextmenu</code> event should be fired. Some user agents may choose not to fire these events if there are other (non-primary) pointers of the same type, or other primary pointers of a different type. User agents may determine that a particular action was not a "clean" tap, click, or long-press (for instance, if an interaction with a finger on a touch screen includes too much movement while the finger is in contact with the screen) and decide not to fire a <code>click</code>, <code>auxclick</code>, or <code>contextmenu</code> event. These aspects of user agent behavior are not defined in this specification, and they may differ between implementations.</p>
         </div>
         <p>Unless otherwise noted, the target of any mapped mouse event SHOULD be the same target as the respective pointer event unless the target is no longer participating in its <code>ownerDocument</code>'s tree. In this case, the mouse event should be fired at the original target's nearest ancestor node (at the time it was removed from the tree) that still participates in its <code>ownerDocument</code>'s tree, meaning that a new event path (based on the new target node) is built for the mouse event.</p>
-        <p>Authors can prevent the production of certain compatibility mouse events by canceling the {{GlobalEventHandlers/pointerdown}} event.</p>
+        <p>Authors can prevent the production of certain compatibility mouse events by canceling the {{pointerdown}} event.</p>
         <p>Mouse events can only be prevented when the pointer is down. Hovering pointers (e.g. a mouse with no buttons pressed) cannot have their mouse events prevented.</p>
         <p>The <code>mouseover</code>, <code>mouseout</code>, <code>mouseenter</code>, and <code>mouseleave</code> events are never prevented (even if the pointer is down).</p>
         <p>Compatibility mouse events can't be prevented when a pointer event {{EventListener}} is set to be {{AddEventListenerOptions/passive}} [[DOM]].</p>
         <section>
             <h2><dfn>Tracking the effective position of the legacy mouse pointer</dfn></h2>
             <p>While only <a>primary pointers</a> can produce compatibility mouse events, <a href="#multiple-primary-pointers">multiple primary pointers</a> can be active simultaneously, each producing its own compatibility mouse events. For compatibility with scripts relying on MouseEvents, the mouse transition events (<code>mouseover</code>, <code>mouseout</code>, <code>mouseenter</code> and <code>mouseleave</code>) SHOULD simulate the movement of a <em>single</em> legacy mouse input. This means that the entry/exit state for every event target is valid, in accordance with [[UIEVENTS]]. User agents SHOULD guarantee this by maintaining the <dfn data-lt="effective legacy mouse pointer position">effective position of the legacy mouse pointer</dfn> in the document as follows.</p>
-            <p>Right before firing a {{GlobalEventHandlers/pointerdown}}, {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointermove}} event, or a {{GlobalEventHandlers/pointerleave}} event at the <code>window</code>, the user agent SHOULD run the following steps:</p>
+            <p>Right before firing a {{pointerdown}}, {{pointerup}} or {{pointermove}} event, or a {{pointerleave}} event at the <code>window</code>, the user agent SHOULD run the following steps:</p>
             <ol>
-                <li>Let |T| be the target of the {{GlobalEventHandlers/pointerdown}}, {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointermove}} event being dispatched. For the {{GlobalEventHandlers/pointerleave}} event, unset |T|.</li>
+                <li>Let |T| be the target of the {{pointerdown}}, {{pointerup}} or {{pointermove}} event being dispatched. For the {{pointerleave}} event, unset |T|.</li>
                 <li>If |T| and current <a>effective legacy mouse pointer position</a> are both unset or they are equal, terminate these steps.</li>
                 <li>Dispatch <code>mouseover</code>, <code>mouseout</code>, <code>mouseenter</code> and <code>mouseleave</code> events as per [[UIEVENTS]] for a mouse moving from the current <a>effective legacy mouse pointer position</a> to |T|. Consider an unset value of either current <a>effective legacy mouse pointer position</a> or |T| as an out-of-window mouse position.</li>
                 <li>Set <a>effective legacy mouse pointer position</a> to |T|.</li>
@@ -1684,18 +1681,18 @@ window.addEventListener("pointermove", function(event) {
             <p>Whenever the user agent is to dispatch a pointer event for a device that supports hover, it SHOULD run the following steps:</p>
             <ol>
                 <li>If the <code>isPrimary</code> property for the pointer event to be dispatched is <code>false</code> then dispatch the pointer event and terminate these steps.</li>
-                <li>If the pointer event to be dispatched is a {{GlobalEventHandlers/pointerdown}}, {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointermove}} event, or a {{GlobalEventHandlers/pointerleave}} event at the <code>window</code>, dispatch compatibility mouse transition events as described in <a>Tracking the effective position of the legacy mouse pointer</a>.</li>
+                <li>If the pointer event to be dispatched is a {{pointerdown}}, {{pointerup}} or {{pointermove}} event, or a {{pointerleave}} event at the <code>window</code>, dispatch compatibility mouse transition events as described in <a>Tracking the effective position of the legacy mouse pointer</a>.</li>
                 <li>Dispatch the pointer event.</li>
-                <li>If the pointer event dispatched was {{GlobalEventHandlers/pointerdown}} and the event was <a data-lt="canceled event">canceled</a>, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
+                <li>If the pointer event dispatched was {{pointerdown}} and the event was <a data-lt="canceled event">canceled</a>, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
                 <li>If the <code>PREVENT MOUSE EVENT</code> flag is <strong>not</strong> set for this <code>pointerType</code> and the pointer event dispatched was:
                     <ul>
-                        <li>{{GlobalEventHandlers/pointerdown}}, then fire a <code>mousedown</code> event.</li>
-                        <li>{{GlobalEventHandlers/pointermove}}, then fire a <code>mousemove</code> event.</li>
-                        <li>{{GlobalEventHandlers/pointerup}}, then fire a <code>mouseup</code> event.</li>
-                        <li>{{GlobalEventHandlers/pointercancel}}, then fire a <code>mouseup</code> event at the <code>window</code>.</li>
+                        <li>{{pointerdown}}, then fire a <code>mousedown</code> event.</li>
+                        <li>{{pointermove}}, then fire a <code>mousemove</code> event.</li>
+                        <li>{{pointerup}}, then fire a <code>mouseup</code> event.</li>
+                        <li>{{pointercancel}}, then fire a <code>mouseup</code> event at the <code>window</code>.</li>
                     </ul>
                 </li>
-                <li>If the pointer event dispatched was {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointercancel}}, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
+                <li>If the pointer event dispatched was {{pointerup}} or {{pointercancel}}, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
             </ol>
         </section>
 
@@ -1710,52 +1707,52 @@ window.addEventListener("pointermove", function(event) {
             <p>This requires that user agents provide a different mapping for these types of input devices. Whenever the user agent is to dispatch a pointer event for a device that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a>, it SHOULD run the following steps:</p>
             <ol>
                 <li>If the <code>isPrimary</code> property for the pointer event to be dispatched is <code>false</code> then dispatch the pointer event and terminate these steps.</li>
-                <li>If the pointer event to be dispatched is {{GlobalEventHandlers/pointerover}} and the {{GlobalEventHandlers/pointerdown}} event has not yet been dispatched for this pointer, then fire a <code>mousemove</code> event (for compatibility with legacy mouse-specific code).</li>
-                <li>If the pointer event to be dispatched is a {{GlobalEventHandlers/pointerdown}}, {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointermove}} event, or a {{GlobalEventHandlers/pointerleave}} event at the <code>window</code>, dispatch compatibility mouse transition events as described in <a>Tracking the effective position of the legacy mouse pointer</a>.</li>
+                <li>If the pointer event to be dispatched is {{pointerover}} and the {{pointerdown}} event has not yet been dispatched for this pointer, then fire a <code>mousemove</code> event (for compatibility with legacy mouse-specific code).</li>
+                <li>If the pointer event to be dispatched is a {{pointerdown}}, {{pointerup}} or {{pointermove}} event, or a {{pointerleave}} event at the <code>window</code>, dispatch compatibility mouse transition events as described in <a>Tracking the effective position of the legacy mouse pointer</a>.</li>
                 <li>Dispatch the pointer event.</li>
-                <li>If the pointer event dispatched was {{GlobalEventHandlers/pointerdown}} and the event was <a data-lt="canceled event">canceled</a>, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
+                <li>If the pointer event dispatched was {{pointerdown}} and the event was <a data-lt="canceled event">canceled</a>, then set the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
                 <li>If the <code>PREVENT MOUSE EVENT</code> flag is <strong>not</strong> set for this <code>pointerType</code> and the pointer event dispatched was:
                     <ul>
-                        <li>{{GlobalEventHandlers/pointerdown}}, then fire a <code>mousedown</code> event.</li>
-                        <li>{{GlobalEventHandlers/pointermove}}, then fire a <code>mousemove</code> event.</li>
-                        <li>{{GlobalEventHandlers/pointerup}}, then fire a <code>mouseup</code> event.</li>
-                        <li>{{GlobalEventHandlers/pointercancel}}, then fire a <code>mouseup</code> event at the <code>window</code>.</li>
+                        <li>{{pointerdown}}, then fire a <code>mousedown</code> event.</li>
+                        <li>{{pointermove}}, then fire a <code>mousemove</code> event.</li>
+                        <li>{{pointerup}}, then fire a <code>mouseup</code> event.</li>
+                        <li>{{pointercancel}}, then fire a <code>mouseup</code> event at the <code>window</code>.</li>
                     </ul>
                 </li>
-                <li>If the pointer event dispatched was {{GlobalEventHandlers/pointerup}} or {{GlobalEventHandlers/pointercancel}}, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
+                <li>If the pointer event dispatched was {{pointerup}} or {{pointercancel}}, clear the <code>PREVENT MOUSE EVENT</code> flag for this <code>pointerType</code>.</li>
             </ol>
             <p>If the user agent supports both Touch Events (as defined in [[TOUCH-EVENTS]]) and Pointer Events, the [=user agent=] MUST NOT generate <em>both</em> the compatibility mouse events as described in this section, and the <a data-cite="touch-events/#mouse-events">fallback mouse events</a> outlined in [[TOUCH-EVENTS]].</p>
             <div class="note">
                 <p>The activation of an element (<code>click</code>) with a primary pointer that <a href=#mapping-for-devices-that-do-not-support-hover>does not support hover</a> (e.g. single finger on a touchscreen) would typically produce the following event sequence:</p>
                 <ol data-class="note-list">
                     <li><code>mousemove</code></li>
-                    <li>{{GlobalEventHandlers/pointerover}}</li>
+                    <li>{{pointerover}}</li>
                     <li><code>pointerenter</code></li>
                     <li><code>mouseover</code></li>
                     <li><code>mouseenter</code></li>
-                    <li>{{GlobalEventHandlers/pointerdown}}</li>
+                    <li>{{pointerdown}}</li>
                     <li><code>mousedown</code></li>
-                    <li>Zero or more {{GlobalEventHandlers/pointermove}} and <code>mousemove</code> events, depending on movement of the pointer</li>
-                    <li>{{GlobalEventHandlers/pointerup}}</li>
+                    <li>Zero or more {{pointermove}} and <code>mousemove</code> events, depending on movement of the pointer</li>
+                    <li>{{pointerup}}</li>
                     <li><code>mouseup</code></li>
-                    <li>{{GlobalEventHandlers/pointerout}}</li>
-                    <li>{{GlobalEventHandlers/pointerleave}}</li>
+                    <li>{{pointerout}}</li>
+                    <li>{{pointerleave}}</li>
                     <li><code>mouseout</code></li>
                     <li><code>mouseleave</code></li>
                     <li><code>click</code></li>
                 </ol>
-                <p>If, however, the {{GlobalEventHandlers/pointerdown}} event is <a data-lt="canceled event">canceled</a> during this interaction then the sequence of events would be:</p>
+                <p>If, however, the {{pointerdown}} event is <a data-lt="canceled event">canceled</a> during this interaction then the sequence of events would be:</p>
                 <ol data-class="note-list">
                     <li><code>mousemove</code></li>
-                    <li>{{GlobalEventHandlers/pointerover}}</li>
+                    <li>{{pointerover}}</li>
                     <li><code>pointerenter</code></li>
                     <li><code>mouseover</code></li>
                     <li><code>mouseenter</code></li>
-                    <li>{{GlobalEventHandlers/pointerdown}}</li>
-                    <li>Zero or more {{GlobalEventHandlers/pointermove}} events, depending on movement of the pointer</li>
-                    <li>{{GlobalEventHandlers/pointerup}}</li>
-                    <li>{{GlobalEventHandlers/pointerout}}</li>
-                    <li>{{GlobalEventHandlers/pointerleave}}</li>
+                    <li>{{pointerdown}}</li>
+                    <li>Zero or more {{pointermove}} events, depending on movement of the pointer</li>
+                    <li>{{pointerup}}</li>
+                    <li>{{pointerout}}</li>
+                    <li>{{pointerleave}}</li>
                     <li><code>mouseout</code></li>
                     <li><code>mouseleave</code></li>
                     <li><code>click</code></li>

--- a/index.html
+++ b/index.html
@@ -668,156 +668,9 @@ dictionary MouseEventInit : EventModifierInit {
 
 
 
-	    <h4>Event Modifier Initializers</h4>
-
-		<p>
-            The {{MouseEvent}} and {{KeyboardEvent}} interfaces share a set of keyboard modifier attributes and support a mechanism for retrieving additional modifier states. The following dictionary enables authors to initialize keyboard modifier attributes of the {{MouseEvent}} and {{KeyboardEvent}} interfaces, as well as the additional modifier states queried via {{KeyboardEvent/getModifierState()}}. The steps for constructing events using this dictionary are defined in the <a href="#constructing-mouse-events">MouseEvent constructors</a> section.
-        </p>
-		<pre class="idl">
-dictionary EventModifierInit : UIEventInit {
-	boolean ctrlKey = false;
-	boolean shiftKey = false;
-	boolean altKey = false;
-	boolean metaKey = false;
-
-	boolean modifierAltGraph = false;
-	boolean modifierCapsLock = false;
-	boolean modifierFn = false;
-	boolean modifierFnLock = false;
-	boolean modifierHyper = false;
-	boolean modifierNumLock = false;
-	boolean modifierScrollLock = false;
-	boolean modifierSuper = false;
-	boolean modifierSymbol = false;
-	boolean modifierSymbolLock = false;
-};
-		</pre>
-
-		<dl dfn-for="EventModifierInit">
-			<dt><dfn>ctrlKey</dfn></dt>
-			<dd>
-				<p>
-                    Initializes the <code>ctrlKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Control</code> key modifier is to be considered active, <code>false</code> otherwise.
-                </p>
-				<p>
-                    When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Control</code> must return <code>true</code>.
-                </p>
-			</dd>
-
-			<dt><dfn>shiftKey</dfn></dt>
-			<dd>
-            <p>
-                Initializes the <code>shiftKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Shift</code> key modifier is to be considered active, <code>false</code> otherwise.
-            </p>
-			<p>
-				When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Shift</code> must return <code>true</code>.
-			</dd>
-			<dt><dfn>altKey</dfn></dt>
-			<dd>
-				<p>
-                    Initializes the <code>altKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Alt</code> (alternative) (or <code class='keycap'>Option</code>) key modifier is to be considered active, <code>false</code> otherwise.
-                </p>
-				<p>
-                    When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Alt</code> must return <code>true</code>.
-                </p>
-			</dd>
-
-			<dt><dfn>metaKey</dfn></dt>
-			<dd>
-				<p>
-                    Initializes the <code>metaKey</code> attribute of the {{MouseEvent}} or {{KeyboardEvent}} objects to <code>true</code> if the <code class='keycap'>Meta</code> key modifier is to be considered active, <code>false</code> otherwise.
-                </p>
-				<p>
-				    When <code>true</code>, implementations must also initialize the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with either the parameter <code class='keycap'>Meta</code> must return <code>true</code>.
-                </p>
-			</dd>
-
-			<dt><dfn>modifierAltGraph</dfn></dt>
-			<dd>
-				<p>
-                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>AltGraph</code> must return <code>true</code>.
-                </p>
-			</dd>
-
-			<dt><dfn>modifierCapsLock</dfn></dt>
-			<dd>
-				<p>
-                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>CapsLock</code> must return <code>true</code>.
-                </p>
-			</dd>
-
-			<dt><dfn>modifierFn</dfn></dt>
-			<dd>
-				<p>
-                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Fn</code> must return <code>true</code>.
-                </p>
-			</dd>
-
-			<dt><dfn>modifierFnLock</dfn></dt>
-			<dd>
-				<p>
-                    Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>FnLock</code> must return <code>true</code>.
-                </p>
-			</dd>
-
-			<dt><dfn>modifierHyper</dfn></dt>
-			<dd>
-				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Hyper</code> must return <code>true</code>.
-			</dd>
-
-			<dt><dfn>modifierNumLock</dfn></dt>
-			<dd>
-				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>NumLock</code> must return <code>true</code>.
-			</dd>
-
-			<dt><dfn>modifierScrollLock</dfn></dt>
-			<dd>
-				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>ScrollLock</code> must return <code>true</code>.
-			</dd>
-
-			<dt><dfn>modifierSuper</dfn></dt>
-			<dd>
-				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Super</code> must return <code>true</code>.
-			</dd>
-
-			<dt><dfn>modifierSymbol</dfn></dt>
-			<dd>
-				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>Symbol</code> must return <code>true</code>.
-			</dd>
-
-			<dt><dfn>modifierSymbolLock</dfn></dt>
-			<dd>
-				Initializes the event object's key modifier state such that calls to the {{MouseEvent/getModifierState()}} or {{KeyboardEvent/getModifierState()}} when provided with the parameter <code class='keycap'>SymbolLock</code> must return <code>true</code>.
-			</dd>
-		</dl>
-
-		
-            <h5>Constructing Mouse Events</h5>
-
-			<p>
-                Generally, when a constructor of an {{Event}} interface, or of an interface inherited from the {{Event}} interface, is invoked, the steps described in [[DOM]] should be followed. However the {{MouseEvent}} interfaces provide additional dictionary members for initializing the internal state of the {{Event}} object's key modifiers: specifically, the internal state queried for using the {{MouseEvent/getModifierState()}} methods. This section supplements the [[DOM]] steps for intializing a new {{MouseEvent}} object with these optional modifier states.
-            </p>
-			<p>
-                For the purposes of constructing a {{MouseEvent}}, or object derived from these objects using the algorithm below, all {{MouseEvent}}, and derived objects have <dfn>internal key modifier state</dfn> which can be set and retrieved using the <a data-cite="uievents/#keys-modifiers">key modifier names</a> described in the <a data-cite="UIEvents-Key/#keys-modifier">Modifier Keys table</a> in [[UIEvents-Key]].
-            </p>
-			<p>
-                The following steps supplement the algorithm defined for constructing events in [[DOM]]:
-            </p>
-            <ul>
-                <li>
-			        If the {{Event}} being constructed is a {{MouseEvent}} object or an object that derives from it, and a {{EventModifierInit}} argument was provided to the constructor, then run the following sub-steps:
-                    <ul>
-                        <li>
-                            For each {{EventModifierInit}} argument, if the dictionary member begins with the string <code>"modifier"</code>, then let the <dfn>key modifier name</dfn> be the dictionary member's name excluding the prefix <code>"modifier"</code>, and set the {{Event}} object's [=internal key modifier state=] that matches the [=key modifier name=] to the corresponding value.
-                        </li>
-                    </ul>
-                </li>
-            </ul>
-
-
-
 
 	    <h4>MouseEvent Algorithms</h4>
+
 
 
 		    <h5>Native OS Requirements</h5>
@@ -846,6 +699,31 @@ dictionary EventModifierInit : UIEventInit {
 			    <li>The x,y mouse coordinates relative to the UA's window viewport</li>
 			    <li>Which keyboard modifiers are currently being held</li>
             </ul>
+
+            
+		
+            <h5>Constructing Mouse Events</h5>
+
+			<p>
+                Generally, when a constructor of an {{Event}} interface, or of an interface inherited from the {{Event}} interface, is invoked, the steps described in [[DOM]] should be followed. However the {{MouseEvent}} interfaces provide additional dictionary members for initializing the internal state of the {{Event}} object's key modifiers: specifically, the internal state queried for using the {{MouseEvent/getModifierState()}} methods. This section supplements the [[DOM]] steps for intializing a new {{MouseEvent}} object with these optional modifier states.
+            </p>
+			<p>
+                For the purposes of constructing a {{MouseEvent}}, or object derived from these objects using the algorithm below, all {{MouseEvent}}, and derived objects have <dfn>internal key modifier state</dfn> which can be set and retrieved using the <a data-cite="uievents/#keys-modifiers">key modifier names</a> described in the <a data-cite="UIEvents-Key/#keys-modifier">Modifier Keys table</a> in [[UIEvents-Key]].
+            </p>
+			<p>
+                The following steps supplement the algorithm defined for constructing events in [[DOM]]:
+            </p>
+            <ul>
+                <li>
+			        If the {{Event}} being constructed is a {{MouseEvent}} object or an object that derives from it, and a {{EventModifierInit}} argument was provided to the constructor, then run the following sub-steps:
+                    <ul>
+                        <li>
+                            For each {{EventModifierInit}} argument, if the dictionary member begins with the string <code>"modifier"</code>, then let the <dfn>key modifier name</dfn> be the dictionary member's name excluding the prefix <code>"modifier"</code>, and set the {{Event}} object's [=internal key modifier state=] that matches the [=key modifier name=] to the corresponding value.
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+
 
 
 		    <h5>Global State for MouseEvent</h5>

--- a/index.html
+++ b/index.html
@@ -2720,7 +2720,7 @@ interface PointerEvent : MouseEvent {
                 <p>If the event is {{pointerdown}}, the associated device is a direct manipulation device, and the target is an {{Element}},
                     then <a>set pointer capture</a> for this {{PointerEvent/pointerId}} to the target element as described in <a>implicit pointer capture</a>.</p>
 
-                <p>Before firing this event, the  <a data-cite="infra">user agent</a> SHOULD treat the target as if the pointing device has moved over it from the |previousTarget| for the purpose of <a data-cite="uievents/#events-mouseevent-event-order">ensuring event ordering</a> [[UIEVENTS]]. If the |needsOverEvent| flag is set, a {{pointerover}} event is needed even if the target element is the same.</p>
+                <p>Before firing this event, the  <a data-cite="infra">user agent</a> SHOULD treat the target as if the pointing device has moved over it from the |previousTarget| for the purpose of <a href="#mouse-event-order">ensuring event ordering</a> [[UIEVENTS]]. If the |needsOverEvent| flag is set, a {{pointerover}} event is needed even if the target element is the same.</p>
 
                 <p>Fire the event to the determined target.</p>
 
@@ -3274,8 +3274,8 @@ function tilt2spherical(tiltX, tiltY) {
 
             <section>
                 <h3>The <dfn><code>click</code>, <code>auxclick</code>, and <code>contextmenu</code> events</dfn></h3>
-                <p>This section is an addition to <a data-cite="uievents/#event-type-click">click</a>,
-                    <a data-cite="uievents/#event-type-auxclick">auxclick</a> and <a data-cite="uievents/#event-type-contextmenu">contextmenu</a>
+                <p>This section is an addition to <code>click</code>,
+                    <code>auxclick</code> and <a data-cite="uievents/#event-type-contextmenu">contextmenu</a>
                     events defined in [[UIEVENTS]].  These events are typically tied to user interface activation, and are fired even from non-pointer input devices, such as keyboards.</p>
                 <p>These events MUST be of type <code>PointerEvent</code>, and are subject to the additional requirements mentioned in the rest of this section.</p>
                 <section>
@@ -4416,6 +4416,128 @@ window.addEventListener("pointermove", function(event) {
         </dl>
     </section>
 
+<section>
+<h2 id="legacy-event-initializers">Legacy Event Initializers</h2>
+
+<p><em>This section is normative.
+The following features are obsolete and should only be implemented by
+<a data-cite="infra">user agents</a> that require compatibility with legacy software. See also the <a data-cite="uievents#legacy-event-initializers">legacy event initializers</a> in [[UIEvents]].</em>
+
+<h3 id="idl-interface-MouseEvent-initializers">Initializers for interface MouseEvent</h3>
+
+		<pre class="idl">
+		partial interface MouseEvent {
+			// Deprecated in this specification
+			undefined initMouseEvent(DOMString typeArg,
+				optional boolean bubblesArg = false,
+				optional boolean cancelableArg = false,
+				optional Window? viewArg = null,
+				optional long detailArg = 0,
+				optional long screenXArg = 0,
+				optional long screenYArg = 0,
+				optional long clientXArg = 0,
+				optional long clientYArg = 0,
+				optional boolean ctrlKeyArg = false,
+				optional boolean altKeyArg = false,
+				optional boolean shiftKeyArg = false,
+				optional boolean metaKeyArg = false,
+				optional short buttonArg = 0,
+				optional EventTarget? relatedTargetArg = null);
+		};
+		</pre>
+
+		<dl data-dfn-for="MouseEvent">
+			<dt><dfn method>initMouseEvent(typeArg)</dfn></dt>
+			<dd>
+				Initializes attributes of a {{MouseEvent}} object. This
+				method has the same behavior as <code>UIEvent.initUIEvent()</code>.
+
+				<p class="warning">
+				The <code>initMouseEvent</code> method is deprecated, but
+				supported for backwards-compatibility with widely-deployed
+				implementations.
+				</p>
+
+				<dl class="parameters">
+					<dt>DOMString typeArg</dt>
+					<dd>
+						Refer to the {{Event/initEvent()}} method for a description of this parameter.
+					</dd>
+
+					<dt>boolean bubblesArg</dt>
+					<dd>
+						Refer to the {{Event/initEvent()}} method for a description of this parameter.
+					</dd>
+
+					<dt>boolean cancelableArg</dt>
+					<dd>
+						Refer to the {{Event/initEvent()}} method for a description of this parameter.
+					</dd>
+
+					<dt>Window? viewArg</dt>
+					<dd>
+						Specifies {{UIEvent/view}}. This value MAY be <code>null</code>.
+					</dd>
+
+					<dt>long detailArg</dt>
+					<dd>
+						Specifies {{UIEvent/detail}}.
+					</dd>
+
+					<dt>long screenXArg</dt>
+					<dd>
+						Specifies {{MouseEvent/screenX}}.
+					</dd>
+
+					<dt>long screenYArg</dt>
+					<dd>
+						Specifies {{MouseEvent/screenY}}.
+					</dd>
+
+					<dt>long clientXArg</dt>
+					<dd>
+						Specifies {{MouseEvent/clientX}}.
+					</dd>
+
+					<dt>long clientYArg</dt>
+					<dd>
+						Specifies {{MouseEvent/clientY}}.
+					</dd>
+
+					<dt>boolean ctrlKeyArg</dt>
+					<dd>
+						Specifies {{MouseEvent/ctrlKey}}.
+					</dd>
+
+					<dt>boolean altKeyArg</dt>
+					<dd>
+						Specifies {{MouseEvent/altKey}}.
+					</dd>
+
+					<dt>boolean shiftKeyArg</dt>
+					<dd>
+						Specifies {{MouseEvent/shiftKey}}.
+					</dd>
+
+					<dt>boolean metaKeyArg</dt>
+					<dd>
+						Specifies {{MouseEvent/metaKey}}.
+					</dd>
+
+					<dt>short buttonArg</dt>
+					<dd>
+						Specifies {{MouseEvent/button}}.
+					</dd>
+
+					<dt>EventTarget? relatedTargetArg</dt>
+					<dd>
+						Specifies {{MouseEvent/relatedTarget}}. This value MAY
+						be <code>null</code>.
+					</dd>
+				</dl>
+			</dd>
+		</dl>
+    </section>
     <section class="appendix">
         <h1>Acknowledgments</h1>
         <p>Many thanks to lots of people for their proposals and recommendations, some of which are incorporated into this document. The group's Chair acknowledges contributions from the following past and present group members and participants:

--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@ interface MouseEvent : UIEvent {
 					    The value of {{MouseEvent/button}} is not updated for events not caused by the depression/release of a mouse button. In these scenarios, take care not to interpret the value <code>0</code> as the left button, but rather as the default value.
 					</p>
 					<p class="note">
-					    Some <a>default actions</a> related to events such as {{mousedown}} and {{mouseup}} depend on the specific mouse button in use.
+					    Some <a>default actions</a> related to events such as [=mousedown=] and [=mouseup=] depend on the specific mouse button in use.
 					</p>
                     <p>
                         The [=un-initialized value=] of this attribute MUST be <code>0</code>.
@@ -532,7 +532,7 @@ interface MouseEvent : UIEvent {
                         During any mouse events, {{MouseEvent/buttons}} MUST be used to indicate which combination of mouse buttons are currently being pressed, expressed as a bitmask.
                     </p>
 					<p class="note">
-					    Though similarly named, the values for the {{MouseEvent/buttons}} attribute and the {{MouseEvent/button}} attribute are very different. The value of {{MouseEvent/button}} is assumed to be valid during {{mousedown}} / {{mouseup}} event handlers, whereas the {{MouseEvent/buttons}} attribute reflects the state of the mouse's buttons for any trusted {{MouseEvent}} object (while it is being dispatched), because it can represent the "no button currently active" state (0).
+					    Though similarly named, the values for the {{MouseEvent/buttons}} attribute and the {{MouseEvent/button}} attribute are very different. The value of {{MouseEvent/button}} is assumed to be valid during [=mousedown=] / [=mouseup=] event handlers, whereas the {{MouseEvent/buttons}} attribute reflects the state of the mouse's buttons for any trusted {{MouseEvent}} object (while it is being dispatched), because it can represent the "no button currently active" state (0).
 					</p>
 
 					<p>
@@ -552,7 +552,7 @@ interface MouseEvent : UIEvent {
 					    Because the sum of any set of button values is a unique number, a content author can use a bitwise operation to determine how many buttons are currently being pressed and which buttons they are, for an arbitrary number of mouse buttons on a device. For example, the value <code>3</code> indicates that the left and right button are currently both pressed, while the value <code>5</code> indicates that the left and middle button are currently both pressed.
                     </p>
 					<p class="note">
-					    Some <a>default actions</a> related to events such as {{mousedown}} and {{mouseup}} depend on the specific mouse button in use.
+					    Some <a>default actions</a> related to events such as [=mousedown=] and [=mouseup=] depend on the specific mouse button in use.
 					</p>
                     <p>
                         The [=un-initialized value=] of this attribute MUST be <code>0</code>.
@@ -672,7 +672,7 @@ dictionary MouseEventInit : EventModifierInit {
 				<dt><dfn>relatedTarget</dfn></dt>
 				<dd>
 					<p>
-                        The {{relatedTarget}} should be initialized to the element whose bounds the mouse pointer just left (in the case of a {{mouseover}} or {{mouseenter}} event) or the element whose bounds the mouse pointer is entering (in the case of a {{mouseout}} or {{mouseleave}} or {{focusout}} event). For other events, this value need not be assigned (and will default to null).
+                        The {{relatedTarget}} should be initialized to the element whose bounds the mouse pointer just left (in the case of a [=mouseover=] or [=mouseenter=] event) or the element whose bounds the mouse pointer is entering (in the case of a [=mouseout=] or [=mouseleave=] or [=focusout=] event). For other events, this value need not be assigned (and will default to null).
 					</p>
 				</dd>
 			</dl>
@@ -1287,7 +1287,7 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td style="text-align:center">
        <td>
       <tr>
@@ -1297,19 +1297,19 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into element A...</em>
       <tr>
        <td class="cell-number">2
-       <td>{{mouseover}}
+       <td>[=mouseover=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">3
-       <td>{{mouseenter}}
+       <td>[=mouseenter=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">4
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td style="text-align:center">A
-       <td>Multiple {{mousemove}} events
+       <td>Multiple [=mousemove=] events
       <tr>
        <td class="cell-number">
        <td>
@@ -1317,12 +1317,12 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved out of element A...</em>
       <tr>
        <td class="cell-number">5
-       <td>{{mouseout}}
+       <td>[=mouseout=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">6
-       <td>{{mouseleave}}
+       <td>[=mouseleave=]
        <td style="text-align:center">A
        <td>
     </table>
@@ -1340,7 +1340,7 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>{{mousemove}}</a>
+       <td>[=mousemove=]</a>
        <td style="text-align:center">
        <td>
       <tr>
@@ -1350,19 +1350,19 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into element A...</em>
       <tr>
        <td class="cell-number">2
-       <td>{{mouseover}}
+       <td>[=mouseover=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">3
-       <td>{{mouseenter}}
+       <td>[=mouseenter=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">4
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td style="text-align:center">A
-       <td>Multiple {{mousemove}} events
+       <td>Multiple [=mousemove=] events
       <tr>
        <td class="cell-number">
        <td>
@@ -1370,24 +1370,24 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into nested element B...</em>
       <tr>
        <td class="cell-number">5
-       <td>{{mouseout}}
+       <td>[=mouseout=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">6
-       <td>{{mouseover}}
+       <td>[=mouseover=]
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">7
-       <td>{{mouseenter}}
+       <td>[=mouseenter=]
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">8
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td style="text-align:center">B
-       <td>Multiple {{mousemove}} events
+       <td>Multiple [=mousemove=] events
       <tr>
        <td class="cell-number">
        <td>
@@ -1395,24 +1395,24 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved from element B into A...</em>
       <tr>
        <td class="cell-number">9
-       <td>{{mouseout}}
+       <td>[=mouseout=]
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">10
-       <td>{{mouseleave}}
+       <td>[=mouseleave=]
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">11
-       <td>{{mouseover}}
+       <td>[=mouseover=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">12
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td style="text-align:center">A
-       <td>Multiple {{mousemove}} events
+       <td>Multiple [=mousemove=] events
       <tr>
        <td class="cell-number">
        <td>
@@ -1420,12 +1420,12 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved out of element A...</em>
       <tr>
        <td class="cell-number">13
-       <td>{{mouseout}}
+       <td>[=mouseout=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">14
-       <td>{{mouseleave}}
+       <td>[=mouseleave=]
        <td style="text-align:center">A
        <td>
     </table>
@@ -1452,7 +1452,7 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td style="text-align:center">
        <td>
       <tr>
@@ -1462,29 +1462,29 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved into element C, the topmost element in the stack</em>
       <tr>
        <td class="cell-number">2
-       <td>{{mouseover}}
+       <td>[=mouseover=]
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">3
-       <td>{{mouseenter}}
+       <td>[=mouseenter=]
        <td style="text-align:center">A
        <td>
       <tr>
        <td class="cell-number">4
-       <td>{{mouseenter}}
+       <td>[=mouseenter=]
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">5
-       <td>{{mouseenter}}
+       <td>[=mouseenter=]
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">6
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td style="text-align:center">C
-       <td>Multiple {{mousemove}} events
+       <td>Multiple [=mousemove=] events
       <tr>
        <td class="cell-number">
        <td>
@@ -1492,28 +1492,28 @@ dictionary MouseEventInit : EventModifierInit {
        <td><em>Pointing device is moved out of element C...</em>
       <tr>
        <td class="cell-number">7
-       <td>{{mouseout}}
+       <td>[=mouseout=]
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">8
-       <td>{{mouseleave}}
+       <td>[=mouseleave=]
        <td style="text-align:center">C
        <td>
       <tr>
        <td class="cell-number">9
-       <td>{{mouseleave}}
+       <td>[=mouseleave=]
        <td style="text-align:center">B
        <td>
       <tr>
        <td class="cell-number">10
-       <td>{{mouseleave}}
+       <td>[=mouseleave=]
        <td style="text-align:center">A
        <td>
     </table>
 
 		<p class="note">
-		    The {{mouseover}}/{{mouseout}} events are only fired once, while {{mouseenter}}/{{mouseleave}} events are fired three times (once to each element).
+		    The [=mouseover=]/[=mouseout=] events are only fired once, while [=mouseenter=]/[=mouseleave=] events are fired three times (once to each element).
 		</p>
 
 		<p>
@@ -1529,65 +1529,65 @@ dictionary MouseEventInit : EventModifierInit {
      <tbody>
       <tr>
        <td class="cell-number">1
-       <td>{{mousedown}}
+       <td>[=mousedown=]
        <td>
       <tr>
        <td class="cell-number">2
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td>OPTIONAL, multiple events, some limits
       <tr>
        <td class="cell-number">3
-       <td>{{mouseup}}
+       <td>[=mouseup=]
        <td>
       <tr>
        <td class="cell-number">4
-       <td>{{click}}
+       <td>[=click=]
        <td>
       <tr>
        <td class="cell-number">5
-       <td>{{mousemove}}
+       <td>[=mousemove=]
        <td>OPTIONAL, multiple events, some limits
       <tr>
        <td class="cell-number">6
-       <td>{{mousedown}}
+       <td>[=mousedown=]
        <td>
       <tr>
        <td class="cell-number">7
-       <td>{{mousemove}}</a>
+       <td>[=mousemove=]</a>
        <td>OPTIONAL, multiple events, some limits
       <tr>
        <td class="cell-number">8
-       <td>{{mouseup}}</a>
+       <td>[=mouseup=]</a>
        <td>
       <tr>
        <td class="cell-number">9
-       <td>{{click}}
+       <td>[=click=]
        <td>
       <tr>
        <td class="cell-number">10
-       <td>{{dblclick}}
+       <td>[=dblclick=]
        <td>
     </table>
 
 		<p class="note">
-		The lag time, degree, distance, and number of {{mousemove}} events allowed between the {{mousedown}} and {{mouseup}} events while still firing a {{click}} or {{dblclick}} event will be implementation-, device-, and platform-specific. This tolerance can aid users that have physical disabilities like unsteady hands when these users interact with a pointing device.
+		The lag time, degree, distance, and number of [=mousemove=] events allowed between the [=mousedown=] and [=mouseup=] events while still firing a [=click=] or [=dblclick=] event will be implementation-, device-, and platform-specific. This tolerance can aid users that have physical disabilities like unsteady hands when these users interact with a pointing device.
 		</p>
 
 		<p>
             Each implementation will determine the appropriate <a>hysteresis</a>
-		tolerance, but in general SHOULD fire {{click}} and {{dblclick}}
-		events when the event target of the associated {{mousedown}} and
-		{{mouseup}} events is the same element with no {{mouseout}} or
-		{{mouseleave}} events intervening, and SHOULD fire {{click}} and
-		{{dblclick}} events on the nearest common inclusive ancestor when the
-		associated {{mousedown}} and {{mouseup}} event targets are
+		tolerance, but in general SHOULD fire [=click=] and [=dblclick=]
+		events when the event target of the associated [=mousedown=] and
+		[=mouseup=] events is the same element with no [=mouseout=] or
+		[=mouseleave=] events intervening, and SHOULD fire [=click=] and
+		[=dblclick=] events on the nearest common inclusive ancestor when the
+		associated [=mousedown=] and [=mouseup=] event targets are
 		different.
         </p>
 
 		<p class="example">
-		If a {{mousedown}} event was targeted at an HTML document's <a data-lt="the body element">body
-		element</a>, and the corresponding {{mouseup}} event was targeted at
-		the <a>document element</a>, then the {{click}} event will be dispatched
+		If a [=mousedown=] event was targeted at an HTML document's <a data-lt="the body element">body
+		element</a>, and the corresponding [=mouseup=] event was targeted at
+		the <a>document element</a>, then the [=click=] event will be dispatched
 		to the <a>document element</a>, since it is the nearest common inclusive
 		ancestor.
 		</p>
@@ -1598,13 +1598,13 @@ dictionary MouseEventInit : EventModifierInit {
 
 		<p class="example">
 		If the target element is removed from the DOM as the result of a
-		{{mousedown}} event, no events for that element will be dispatched
-		for {{mouseup}}, {{click}}, or {{dblclick}}, nor any default
-		activation events. However, the {{mouseup}} event will still be
+		[=mousedown=] event, no events for that element will be dispatched
+		for [=mouseup=], [=click=], or [=dblclick=], nor any default
+		activation events. However, the [=mouseup=] event will still be
 		dispatched on the element that is exposed to the mouse after the removal
 		of the initial target element. Similarly, if the target element is
-		removed from the DOM during the dispatch of a {{mouseup}} event, the
-		{{click}} and subsequent events will not be dispatched.
+		removed from the DOM during the dispatch of a [=mouseup=] event, the
+		[=click=] and subsequent events will not be dispatched.
 		</p>
 
 	<h4>Mouse Event Types</h4>
@@ -1660,7 +1660,7 @@ dictionary MouseEventInit : EventModifierInit {
         </ul>
     </table>
             <p>
-			The {{auxclick}} event type MUST be dispatched on the <a>topmost
+			The [=auxclick=] event type MUST be dispatched on the <a>topmost
 			event target</a> indicated by the pointer, when the user presses
 			down and releases the non-primary pointer button, or otherwise activates
 			the pointer in a manner that simulates such an action. The actuation
@@ -1670,27 +1670,27 @@ dictionary MouseEventInit : EventModifierInit {
 			device button.
 
 			<p>
-            The {{auxclick}} event should only be fired for the non-primary pointer
+            The [=auxclick=] event should only be fired for the non-primary pointer
 			buttons (i.e., when {{MouseEvent/button}} value is not <code>0</code>,
 			{{MouseEvent/buttons}} value is greater than <code>1</code>). The primary button
 			(like the left button on a standard mouse) MUST NOT fire
-			{{auxclick}} events. See {{click}} for a corresponding event that
+			[=auxclick=] events. See [=click=] for a corresponding event that
 			is associated with the primary button.
 
 			<p>
-            The {{auxclick}} event MAY be preceded by the {{mousedown}} and
-			{{mouseup}} events on the same element, disregarding changes
+            The [=auxclick=] event MAY be preceded by the [=mousedown=] and
+			[=mouseup=] events on the same element, disregarding changes
 			between other node types (e.g., text nodes).  Depending upon the
-			environment configuration, the {{auxclick}} event MAY be dispatched
-			if one or more of the event types {{mouseover}},
-			{{mousemove}}, and {{mouseout}} occur between the press and
+			environment configuration, the [=auxclick=] event MAY be dispatched
+			if one or more of the event types [=mouseover=],
+			[=mousemove=], and [=mouseout=] occur between the press and
 			release of the pointing device button.
 
 			<p>
-            The <a>default action</a> of the {{auxclick}} event type varies
+            The <a>default action</a> of the [=auxclick=] event type varies
 			based on the [=Event/target=] of the event and the value of the
 			{{MouseEvent/button}} or {{MouseEvent/buttons}} attributes. Typical
-			<a>default actions</a> of the {{auxclick}} event type are as follows:
+			<a>default actions</a> of the [=auxclick=] event type are as follows:
 
 			<ul><li>
                 If the [=Event/target=] has associated activation behavior,
@@ -1711,8 +1711,8 @@ dictionary MouseEventInit : EventModifierInit {
 });
 </code></pre>
 			<p class="note">
-			In the case of right button, the {{auxclick}} event is dispatched after
-			any EVENT{contextmenu} event. Note that some user agents swallow all input
+			In the case of right button, the [=auxclick=] event is dispatched after
+			any [=contextmenu=] event. Note that some user agents swallow all input
 			events while a context menu is being displayed, so auxclick may not be
 			available to applications in such scenarios.
 			See <a href="#example-auxclick-right"></a> for more clarification.
@@ -1778,7 +1778,7 @@ myDiv.addEventListener("auxclick", function(e) {
         </ul>
     </table>
             <p>
-			The {{click}} event type MUST be dispatched on the <a>topmost
+			The [=click=] event type MUST be dispatched on the <a>topmost
 			event target</a> indicated by the pointer, when the user presses
 			down and releases the primary pointer button, or otherwise activates
 			the pointer in a manner that simulates such an action. The actuation
@@ -1788,22 +1788,22 @@ myDiv.addEventListener("auxclick", function(e) {
 			device button.
 
 			<p>
-			The {{click}} event should only be fired for the primary pointer
+			The [=click=] event should only be fired for the primary pointer
 			button (i.e., when {{MouseEvent/button}} value is <code>0</code>,
 			{{MouseEvent/buttons}} value is <code>1</code>). Secondary buttons
 			(like the middle or right button on a standard mouse) MUST NOT fire
-			{{click}} events. See {{auxclick}} for a corresponding event that
+			[=click=] events. See [=auxclick=] for a corresponding event that
 			is associated with the non-primary buttons.
 
 			<p>
-			The {{click}} event MAY be preceded by the {{mousedown}} and
-			{{mouseup}} events on the same element, disregarding changes
+			The [=click=] event MAY be preceded by the [=mousedown=] and
+			[=mouseup=] events on the same element, disregarding changes
 			between other node types (e.g., text nodes).  Depending upon the
-			environment configuration, the {{click}} event MAY be dispatched
-			if one or more of the event types {{mouseover}},
-			{{mousemove}}, and {{mouseout}} occur between the press and
-			release of the pointing device button.  The {{click}} event MAY
-			also be followed by the {{dblclick}} event.
+			environment configuration, the [=click=] event MAY be dispatched
+			if one or more of the event types [=mouseover=],
+			[=mousemove=], and [=mouseout=] occur between the press and
+			release of the pointing device button.  The [=click=] event MAY
+			also be followed by the [=dblclick=] event.
 
 			<p class="example">
 			If a user mouses down on a text node child of a
@@ -1813,33 +1813,33 @@ myDiv.addEventListener("auxclick", function(e) {
 			block of that <code>&lt;p&gt;</code> element (i.e., the pointer is
 			between lines of the same text block, but not over the text node per
 			se), then subsequently mouses up, this will likely still trigger a
-			{{click}} event (if it falls within the normal temporal
-			<a>hysteresis</a> for a {{click}}), since the user has stayed
+			[=click=] event (if it falls within the normal temporal
+			<a>hysteresis</a> for a [=click=]), since the user has stayed
 			within the scope of the same element. Note that user-agent-generated
 			mouse events are not dispatched on text nodes.
 			</p>
 
 			<p>
 			In addition to being associated with pointer devices, the
-			{{click}} event type MUST be dispatched as part of an element
+			[=click=] event type MUST be dispatched as part of an element
 			activation.
 
 			<p class="note">
 			For maximum accessibility, content authors are encouraged to use the
-			{{click}} event type when defining activation behavior for custom
+			[=click=] event type when defining activation behavior for custom
 			controls, rather than other pointing-device event types such as
-			{{mousedown}} or {{mouseup}}, which are more device-specific.
-			Though the {{click}} event type has its origins in pointer
+			[=mousedown=] or [=mouseup=], which are more device-specific.
+			Though the [=click=] event type has its origins in pointer
 			devices (e.g., a mouse), subsequent implementation enhancements have
 			extended it beyond that association, and it can be considered a
 			device-independent event type for element activation.
 			</p>
 
 			<p>
-			The <a>default action</a> of the {{click}} event type varies
+			The <a>default action</a> of the [=click=] event type varies
 			based on the [=Event/target=] of the event and the value of the
 			{{MouseEvent/button}} or {{MouseEvent/buttons}} attributes. Typical
-			<a>default actions</a> of the {{click}} event type are as follows:
+			<a>default actions</a> of the [=click=] event type are as follows:
 
 		    <ul>
 				<li>If the [=Event/target=] has associated activation behavior,
@@ -1896,11 +1896,11 @@ myDiv.addEventListener("auxclick", function(e) {
 
 			<p>
 			When the {{contextmenu}} event is triggered by right mouse button, the
-			{{contextmenu}} event MUST be dispatched after the {{mousedown}} event.
+			{{contextmenu}} event MUST be dispatched after the [=mousedown=] event.
 
 			<p class="note">
 			Depending on the platform, the {{contextmenu}} event may be dispatched
-			before or after the {{mouseup}} event.
+			before or after the [=mouseup=] event.
 			</p>
 
 		<h5><dfn>dblclick</dfn></h5>
@@ -1959,26 +1959,26 @@ myDiv.addEventListener("auxclick", function(e) {
 			of a pointing device is clicked twice over an element. The
 			definition of a double click depends on the environment
 			configuration, except that the event target MUST be the same between
-			{{mousedown}}, {{mouseup}}, and {{dblclick}}. This event
-			type MUST be dispatched after the event type {{click}} if a click
+			[=mousedown=], [=mouseup=], and [=dblclick=]. This event
+			type MUST be dispatched after the event type [=click=] if a click
 			and double click occur simultaneously, and after the event type
-			{{mouseup}} otherwise.
+			[=mouseup=] otherwise.
 
 			<p>
-			As with the {{click}} event, the {{dblclick}} event should
+			As with the [=click=] event, the [=dblclick=] event should
 			only be fired for the primary pointer button. Secondary buttons MUST
-			NOT fire {{dblclick}} events.
+			NOT fire [=dblclick=] events.
 
 			<p class="note">
-			Canceling the {{click}} event does not affect the firing of a
-			{{dblclick}} event.
+			Canceling the [=click=] event does not affect the firing of a
+			[=dblclick=] event.
 			</p>
 
-			As with the {{click}} event type, the <a>default action</a> of
-			the {{dblclick}} event type varies based on the [=Event/target=] of the event and the value of the {{MouseEvent/button}}
+			As with the [=click=] event type, the <a>default action</a> of
+			the [=dblclick=] event type varies based on the [=Event/target=] of the event and the value of the {{MouseEvent/button}}
 			or {{MouseEvent/buttons}} attributes. The typical
-			<a>default actions</a> of the {{dblclick}} event type match those
-			of the {{click}} event type.
+			<a>default actions</a> of the [=dblclick=] event type match those
+			of the [=click=] event type.
 
 		<h5><dfn>mousedown</dfn></h5>
 
@@ -2009,7 +2009,7 @@ myDiv.addEventListener("auxclick", function(e) {
 			<ul>
 <li>{{Event}}.{{Event/target}} : <a>topmost event target</a></li>
 <li>{{UIEvent}}.{{UIEvent/view}} : {{Window}}</li>
-<li>{{UIEvent}}.{{UIEvent/detail}} : indicates the <a href="#current-click-count">current click count</a> incremented by one. For example, if no click happened before the {{mousedown}}, {{UIEvent/detail}} will contain the value <code>1</code></li>
+<li>{{UIEvent}}.{{UIEvent/detail}} : indicates the <a href="#current-click-count">current click count</a> incremented by one. For example, if no click happened before the [=mousedown=], {{UIEvent/detail}} will contain the value <code>1</code></li>
 <li>{{MouseEvent}}.{{MouseEvent/screenX}} : value based on the pointer position on
 the screen</li>
 <li>{{MouseEvent}}.{{MouseEvent/screenY}} : value based on the pointer position on
@@ -2035,14 +2035,14 @@ within the containing element</li>
 			button is pressed over an element.
 
 			<p class="note">
-			Many implementations use the {{mousedown}} event to begin a
+			Many implementations use the [=mousedown=] event to begin a
 			variety of contextually dependent <a>default actions</a>. These
 			default actions can be prevented if this event is canceled. Some of
 			these default actions could include: beginning a drag/drop
 			interaction with an image or link, starting text selection, etc.
 			Additionally, some implementations provide a mouse-driven panning
 			feature that is activated when the middle mouse button is pressed at
-			the time the {{mousedown}} event is dispatched.
+			the time the [=mousedown=] event is dispatched.
 			</p>
 
 		<h5><dfn>mouseenter</dfn></h5>
@@ -2100,7 +2100,7 @@ within the containing element</li>
 			is moved onto the boundaries of an element or one of its descendent
 			elements.  A <a data-cite="infra">user agent</a> MUST also dispatch this event when the
 			element or one of its descendants moves to be underneath the primary
-			pointing device. This event type is similar to {{mouseover}}, but
+			pointing device. This event type is similar to [=mouseover=], but
 			differs in that it does not bubble, and MUST NOT be dispatched when
 			the pointer device moves from an element onto the boundaries of one
 			of its descendent elements.
@@ -2109,7 +2109,7 @@ within the containing element</li>
 			There are similarities between this event type and the CSS
 			<a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes"
 			title="Selectors"><code>:hover</code> pseudo-class</a> [[CSS2]].
-			See also the {{mouseleave}} event type.
+			See also the [=mouseleave=] event type.
 			</p>
 
 		<h5><dfn>mouseleave</dfn></h5>
@@ -2167,7 +2167,7 @@ within the containing element</li>
 			is moved off of the boundaries of an element and all of its
 			descendent elements.  A <a data-cite="infra">user agent</a> MUST also dispatch this event
 			when the element or one of its descendants moves to be no longer underneath
-			the primary pointing device. This event type is similar to {{mouseout}},
+			the primary pointing device. This event type is similar to [=mouseout=],
 			but differs in that does not bubble, and that it MUST NOT be
 			dispatched until the pointing device has left the boundaries of the
 			element and the boundaries of all of its children.
@@ -2176,7 +2176,7 @@ within the containing element</li>
 			There are similarities between this event type and the CSS
 			<a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes"
 			title="Selectors"><code>:hover</code> pseudo-class</a> [[CSS2]].
-			See also the {{mouseenter}} event type.
+			See also the [=mouseenter=] event type.
 			</p>
 
 		<h5><dfn>mousemove</dfn></h5>
@@ -2232,7 +2232,7 @@ within the containing element</li>
 			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
 			is moved while it is over an element.  The frequency rate of events
 			while the pointing device is moved is implementation-, device-, and
-			platform-specific, but multiple consecutive {{mousemove}} events
+			platform-specific, but multiple consecutive [=mousemove=] events
 			SHOULD be fired for sustained pointer-device movement, rather than a
 			single event for each instance of mouse movement.  Implementations
 			are encouraged to determine the optimal frequency rate to balance
@@ -2240,7 +2240,7 @@ within the containing element</li>
 
 			<p class="note">
 			In some implementation environments, such as a browser,
-			{{mousemove}} events can continue to fire if the user began a
+			[=mousemove=] events can continue to fire if the user began a
 			drag operation (e.g., a mouse button is pressed) and the pointing
 			device has left the boundary of the user agent.
 			</p>
@@ -2305,12 +2305,12 @@ within the containing element</li>
 			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
 			is moved off of the boundaries of an element or when the element is
 			moved to be no longer underneath the primary pointing device.
-			This event type is similar to {{mouseleave}}, but differs in that
+			This event type is similar to [=mouseleave=], but differs in that
 			does bubble, and that it MUST be dispatched when the pointer device
 			moves from an element onto the boundaries of one of its descendent elements.
 
 			<p class="note">
-			See also the {{mouseover}} event type.
+			See also the [=mouseover=] event type.
 			</p>
 
 		<h5><dfn>mouseover</dfn></h5>
@@ -2367,12 +2367,12 @@ within the containing element</li>
 			A <a data-cite="infra">user agent</a> MUST dispatch this event when a pointing device
 			is moved onto the boundaries of an element or when the element is
 			moved to be underneath the primary pointing device.
-			This event type is similar to {{mouseenter}}, but differs in
+			This event type is similar to [=mouseenter=], but differs in
 			that it bubbles, and that it MUST be dispatched when the pointer device moves onto the
 			boundaries of an element whose ancestor element is the [=Event/target=] for the same <a>event listener</a> instance.
 
 			<p class="note">
-			See also the {{mouseout}} event type.
+			See also the [=mouseout=] event type.
 			</p>
 
 		        <h5><dfn>mouseup</dfn></h5>
@@ -2431,7 +2431,7 @@ within the containing element</li>
 
 			<p class="note">
 			In some implementation environments, such as a browser, a
-			{{mouseup}} event can be dispatched even if the pointing device
+			[=mouseup=] event can be dispatched even if the pointing device
 			has left the boundary of the user agent, e.g., if the user began a
 			drag operation with a mouse button pressed.
 			</p>
@@ -3319,10 +3319,10 @@ function tilt2spherical(tiltX, tiltY) {
 
 	The sign (positive or negative) of the values of the deltaX, deltaY, and deltaZ attributes
 	MUST be consistent between multiple dispatches of the
-	EVENT{wheel} event while the
+	[=wheel=] event while the
 	motion of the actual wheel device is rotating/moving in the same direction.
 	If a user agent scrolls as the default action of the
-	EVENT{wheel} event then the sign
+	[=wheel=] event then the sign
 	of the <a>delta</a> SHOULD be given by a right-hand coordinate system where positive X,
 	Y, and Z axes are directed towards the right-most edge, bottom-most edge, and farthest
 	depth (away from the user) of the document, respectively.
@@ -3351,7 +3351,7 @@ function tilt2spherical(tiltX, tiltY) {
 	<h4 id="interface-wheelevent">Interface WheelEvent</h4>
 
 		The {{WheelEvent}} interface provides specific contextual information
-		associated with EVENT{wheel} events.
+		associated with [=wheel=] events.
 
 		To create an instance of the {{WheelEvent}} interface, use the {{WheelEvent}} constructor,
 		passing an optional {{WheelEventInit}} dictionary.
@@ -3396,7 +3396,7 @@ function tilt2spherical(tiltX, tiltY) {
 
 				<dt><dfn>deltaX</dfn></dt>
 				<dd>
-					In user agents where the default action of the EVENT{wheel}
+					In user agents where the default action of the [=wheel=]
 					event is to scroll, the value MUST be the measurement along the
 					x-axis (in pixels, lines, or pages) to be scrolled in the case
 					where the event is not cancelled. Otherwise, this is an
@@ -3409,7 +3409,7 @@ function tilt2spherical(tiltX, tiltY) {
 
 				<dt><dfn>deltaY</dfn></dt>
 				<dd>
-					In user agents where the default action of the EVENT{wheel}
+					In user agents where the default action of the [=wheel=]
 					event is to scroll, the value MUST be the measurement along the
 					y-axis (in pixels, lines, or pages) to be scrolled in the case
 					where the event is not cancelled. Otherwise, this is an
@@ -3422,7 +3422,7 @@ function tilt2spherical(tiltX, tiltY) {
 
 				<dt><dfn>deltaZ</dfn></dt>
 				<dd>
-					In user agents where the default action of the EVENT{wheel}
+					In user agents where the default action of the [=wheel=]
 					event is to scroll, the value MUST be the measurement along the
 					z-axis (in pixels, lines, or pages) to be scrolled in the case
 					where the event is not cancelled. Otherwise, this is an
@@ -3562,10 +3562,10 @@ function tilt2spherical(tiltX, tiltY) {
 			(such as a mouse-ball, certain tablets or touchpads, etc.) has
 			emulated such an action. Depending on the platform and input device,
 			diagonal wheel <a>deltas</a> MAY be delivered either as a single
-			EVENT{wheel} event with multiple non-zero axes or as separate
-			EVENT{wheel} events for each non-zero axis.
+			[=wheel=] event with multiple non-zero axes or as separate
+			[=wheel=] events for each non-zero axis.
 
-			The typical <a>default action</a> of the EVENT{wheel} event type is
+			The typical <a>default action</a> of the [=wheel=] event type is
 			to scroll (or in some cases, zoom) the document by the indicated
 			amount.  If this event is canceled, the implementation MUST NOT
 			scroll or zoom the document (or perform whatever other

--- a/index.html
+++ b/index.html
@@ -166,11 +166,26 @@
 </head>
 <body>
     <section id="abstract">
-        <p>The features in this specification extend or modify those found in Pointer Events, a W3C Recommendation that describes events and related interfaces for handling hardware-agnostic pointer input from devices including a mouse, pen, or touchscreen. For compatibility with existing mouse-based content, this specification also describes a mapping to fire Mouse Events for other pointer device types.</p>
+        <p>
+            The Pointer Events specification defines a unified hardware-agnostic framework for handling input from various devices, including mice, touchscreens, and pens/styluses. By providing a single set of events (e.g., pointerdown, pointermove, pointerup), it allows developers to support diverse input methods without writing device-specific logic for each.
+        </p>
+        <p>
+            This specification also defines Mouse and Wheel Events, as well as a mapping to fire Mouse Events for other pointer device types.
+        </p>
     </section>
 
     <section id="sotd">
-        <p>This specification is an update to [[PointerEvents3]]. It includes editorial clarifications and new features that facilitate more use cases.</p>
+        <p>
+            This specification is an update to [[PointerEvents3]] specification. It also includes the Mouse and Wheel Events, previously in the [[UIEVENTS]] specification.
+        
+        <p>
+            This revision includes new features:
+        
+        <ul>
+            <li><code>persistentDeviceId</code> to provide a stable identifier for input devices across multiple interactions.</li>
+            <li>new CSS <a><code>touch-action</code> values</a>: <code>pan-left</code>, <code>pan-right</code>, <code>pan-up</code>, <code>pan-down</code></li>
+        </ul>
+
     </section>
 
     <section id="intro" class="informative">


### PR DESCRIPTION
* Import the PointerEvent algorithms from uievents

* Remove the event types from the GlobalEventHandlers definitions

* Import Mouse and Wheel Events from uievents

* Remove definition for "canceled event". Use '[=canceled flag=] is set' instead.

- [ ] https://github.com/w3c/uievents/pull/411
- [ ] https://github.com/web-platform-tests/wpt/pull/57644
- [x] https://github.com/mdn/content/pull/43011
- [x] https://github.com/mdn/browser-compat-data/pull/28974
- [x] https://github.com/web-platform-dx/web-features/pull/3690
- [x] CanIUse (no need)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/564.html" title="Last updated on Feb 10, 2026, 9:02 PM UTC (50eb61e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/564/146766e...50eb61e.html" title="Last updated on Feb 10, 2026, 9:02 PM UTC (50eb61e)">Diff</a>