### PR TITLE
Allow pointerup-activated elements to set click target differently.

### DIFF
--- a/index.html
+++ b/index.html
@@ -894,9 +894,13 @@ function tilt2spherical(tiltX, tiltY) {
                         <li>
                             <p>Define |target| as follows:</p>
 
-                            <p>If |event| is a <code>contextmenu</code> event, or |userEvent| was dispatched while the corresponding pointer was captured, then let |target| be the target of |userEvent|.</p>
+                            <ol>
+                                <li>If |event| is a <code>contextmenu</code> event, or |userEvent| was dispatched while the corresponding pointer was captured, then let |target| be the target of |userEvent|.</li>
 
-                            <p>Otherwise (|event| is a <code>click</code> or <code>auxclick</code> event for which |userEvent| is a <code>pointerup</code> event that was dispatched uncaptured) let |target| be the nearest common inclusive ancestor of the corresponding <code>pointerdown</code> and <code>pointerup</code> targets in the DOM at the moment |event| is being dispatched.</p>
+                                <li>Otherwise, if the nearest ancestor |specialAncestor| of the <code>pointerup</code> target that is a <a>pointerup-activated element</a> is not also an ancestor of the <code>pointerdown</code> target, let |target| be |specialAncestor|.</li>
+
+                                <li>Otherwise, let |target| be the nearest common inclusive ancestor of the corresponding <code>pointerdown</code> and <code>pointerup</code> targets in the DOM at the moment |event| is being dispatched.</li>
+                            </ol>
                         </li>
 
                         <li>
@@ -904,6 +908,10 @@ function tilt2spherical(tiltX, tiltY) {
                             <div class="note">If |userEvent| was captured, |event| is dispatched to the capturing target of |userEvent| even though the {{GlobalEventHandlers/lostpointercapture}} event with the same {{PointerEvent/pointerId}} has been dispatched already.</div>
                         </li>
                     </ol>
+
+                    <p>Other specifications can define elements to be a <dfn>pointerup-activated element</dfn>.  They should do this for elements that are typically activated by a pointerup gesture even when the pointerdown gesture occurred elsewhere.</p>
+
+                    <p class="note">Typical examples of <a>pointerup-activated elements</a> might be things like menu items, or options in a select or combobox popup.</p>
                 </section>
             </section>
         </section>


### PR DESCRIPTION
This allows other specifications to define particular elements to be pointerup-activated elements, which have different behavior for choosing the element that gets the click event.  These elements can get a click event when the pointerup is inside them, even when the pointerdown is not.

This is the approach I'd like to take to implement what the OpenUI CG resolved that it wanted in:
https://github.com/openui/open-ui/issues/1312#issuecomment-3469585173

This is desirable so that author-defined `click` handlers will work reliably for activations of these elements, which would not otherwise be the case.  This allows avoiding a behavior that would be confusing to authors where a `click` handler would work for many user gestures that activate the element but also fail to work for a significant number of the gestures that do so.

I'm curious what you think of this approach.  I realize it might require some amount of discussion, but given that I think the spec change needed is quite small I figured I'd try starting that discussion with the PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/pointerevents/pull/637.html" title="Last updated on Feb 5, 2026, 3:52 PM UTC (c2b0269)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/637/146766e...dbaron:c2b0269.html" title="Last updated on Feb 5, 2026, 3:52 PM UTC (c2b0269)">Diff</a>