### PR TITLE
Export topmost event target definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -4365,7 +4365,7 @@ window.addEventListener("pointermove", function(event) {
                 <dd>A hardware-agnostic representation of input devices that can target a specific coordinate (or set of coordinates) on a screen, such as a mouse, pen, or touch contact.</dd>
             <dt><dfn>rotation</dfn></dt>
                 <dd>An indication of incremental change on an input device using the {{WheelEvent}} interface. On some devices this MAY be a literal rotation of a wheel, while on others, it MAY be movement along a flat surface, or pressure on a particular button.</dd>
-            <dt><dfn>topmost event target</dfn></dt>
+            <dt><dfn class="export">topmost event target</dfn></dt>
             <dd>The <a>topmost event target</a> MUST be the element highest in the rendering order which is capable of being a [=Event/target=]. In graphical user interfaces this is the element under the user's pointing device. A user interface's <q>hit testing</q> facility is used to determine the target. For specific details regarding hit testing and stacking order, refer to the <a>host language</a>.</dd>
         </dl>
     </section>


### PR DESCRIPTION
This is used by [Captured Surface Control: Subroutine: Forward wheel event](https://w3c.github.io/mediacapture-surface-control/#subroutine-forward-wheel-event).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/pull/640.html" title="Last updated on Feb 15, 2026, 7:36 PM UTC (af00997)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/640/7a3f80d...af00997.html" title="Last updated on Feb 15, 2026, 7:36 PM UTC (af00997)">Diff</a>