### PR TITLE
Add `momentum` attribute in WheelEvent to mark inertial scroll events.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3370,6 +3370,7 @@ function tilt2spherical(tiltX, tiltY) {
 				readonly attribute double deltaY;
 				readonly attribute double deltaZ;
 				readonly attribute unsigned long deltaMode;
+				readonly attribute boolean momentum;
 			};
 			</pre>
 
@@ -3445,6 +3446,18 @@ function tilt2spherical(tiltX, tiltY) {
 
 					The <a>un-initialized value</a> of this attribute MUST be
 					<code>0</code>.
+				</dd>
+
+				<dt><dfn>momentum</dfn></dt>
+				<dd>
+					This attribute must be <code>true</code> if this event is
+					synthesized by the platform to simulate scroll inertia after
+					the user has ended the physical scroll interaction (e.g.
+					lifted the finger from a trackpad after a fling), and
+					<code>false</code> otherwise.
+
+					The <a>un-initialized value</a> of this attribute MUST be
+					<code>false</code>.
 				</dd>
 			</dl>
 


### PR DESCRIPTION
Closes #587


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mustaqahmed/pointerevents/pull/643.html" title="Last updated on May 6, 2026, 3:30 PM UTC (a0f6431)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pointerevents/643/fc8ba9d...mustaqahmed:a0f6431.html" title="Last updated on May 6, 2026, 3:30 PM UTC (a0f6431)">Diff</a>